### PR TITLE
Rename app from 'nhacte' to 'nhac'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# nhacte
+# nhac
 
 A new Flutter project.
 

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 android {
-    namespace = "dev.myyc.nhacte"
+    namespace = "dev.myyc.nhac"
     compileSdk = flutter.compileSdkVersion
     ndkVersion = flutter.ndkVersion
 
@@ -21,7 +21,7 @@ android {
 
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
-        applicationId = "dev.myyc.nhacte"
+        applicationId = "dev.myyc.nhac"
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
         minSdk = flutter.minSdkVersion

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -7,7 +7,7 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK"/>
     
     <application
-        android:label="nhacte"
+        android:label="nhac"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
         <activity

--- a/android/app/src/main/kotlin/dev/myyc/nhac/MainActivity.kt
+++ b/android/app/src/main/kotlin/dev/myyc/nhac/MainActivity.kt
@@ -1,4 +1,4 @@
-package dev.myyc.nhacte
+package dev.myyc.nhac
 
 import com.ryanheise.audioservice.AudioServiceActivity
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -19,7 +19,7 @@ import 'services/audio_handler.dart';
 import 'services/navidrome_api.dart';
 import 'theme/app_theme.dart';
 
-late NhacteAudioHandler? audioHandler;
+late NhacAudioHandler? audioHandler;
 late AudioPlayer globalAudioPlayer;
 
 void main() async {
@@ -47,17 +47,17 @@ void main() async {
       password: '',
     );
     audioHandler = await AudioService.init(
-      builder: () => NhacteAudioHandler(
+      builder: () => NhacAudioHandler(
         globalAudioPlayer, // Use the shared player instance
         dummyApi, // This will be properly set later in PlayerProvider
       ),
       config: const AudioServiceConfig(
-        androidNotificationChannelId: 'dev.myyc.nhacte.channel.audio',
+        androidNotificationChannelId: 'dev.myyc.nhac.channel.audio',
         androidNotificationChannelName: 'Music playback',
         androidNotificationOngoing: false,
         androidStopForegroundOnPause: false, // Keep service alive during pause
       ),
-    ) as NhacteAudioHandler;
+    ) as NhacAudioHandler;
   } else {
     audioHandler = null;
   }
@@ -84,7 +84,7 @@ void main() async {
     });
   }
   
-  runApp(const NhacteApp());
+  runApp(const NhacApp());
   
   if (Platform.isWindows || Platform.isLinux || Platform.isMacOS) {
     doWhenWindowReady(() {
@@ -97,8 +97,8 @@ void main() async {
   }
 }
 
-class NhacteApp extends StatelessWidget {
-  const NhacteApp({super.key});
+class NhacApp extends StatelessWidget {
+  const NhacApp({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -132,7 +132,7 @@ class NhacteApp extends StatelessWidget {
               child: Focus(
                 autofocus: true,
                 child: MaterialApp(
-                  title: 'Nhacte',
+                  title: 'Nhac',
                   debugShowCheckedModeBanner: false,
                   theme: themeProvider.getLightTheme(),
                   darkTheme: themeProvider.getDarkTheme(),

--- a/lib/providers/player_provider.dart
+++ b/lib/providers/player_provider.dart
@@ -21,7 +21,7 @@ class PlayerProvider extends ChangeNotifier {
   CacheService? _cacheService;
   Timer? _preloadTimer;
   ConcatenatingAudioSource? _playlist;
-  NhacteAudioHandler? _audioHandler;
+  NhacAudioHandler? _audioHandler;
   
   Song? _currentSong;
   String? _currentCoverArtPath; // Local path to cached cover art

--- a/lib/screens/albums_screen.dart
+++ b/lib/screens/albums_screen.dart
@@ -118,7 +118,7 @@ class _AlbumsScreenState extends State<AlbumsScreen> {
                             child: CachedNetworkImage(
                               imageUrl: api.getCoverArtUrl(album.coverArt),
                               httpHeaders: const {
-                                'User-Agent': 'nhacte/1.0.0',
+                                'User-Agent': 'nhac/1.0.0',
                               },
                               fit: BoxFit.cover,
                               width: double.infinity,

--- a/lib/screens/artists_screen.dart
+++ b/lib/screens/artists_screen.dart
@@ -94,7 +94,7 @@ class _ArtistsScreenState extends State<ArtistsScreen> {
                       child: CachedNetworkImage(
                         imageUrl: api.getCoverArtUrl(artist.coverArt, size: 100),
                         httpHeaders: const {
-                          'User-Agent': 'nhacte/1.0.0',
+                          'User-Agent': 'nhac/1.0.0',
                         },
                         fit: BoxFit.cover,
                         width: 40,

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -141,7 +141,7 @@ class _LoginScreenState extends State<LoginScreen> {
                             ),
                             const SizedBox(height: 24),
                             Text(
-                              'Welcome to Nhacte',
+                              'Welcome to Nhac',
                               style: theme.textTheme.headlineMedium?.copyWith(
                                 fontWeight: FontWeight.w700,
                                 letterSpacing: -0.5,

--- a/lib/screens/recently_added_screen.dart
+++ b/lib/screens/recently_added_screen.dart
@@ -143,7 +143,7 @@ class _RecentlyAddedScreenState extends State<RecentlyAddedScreen> {
                               child: CachedNetworkImage(
                                 imageUrl: api.getCoverArtUrl(album.coverArt, size: 160),
                                 httpHeaders: const {
-                                  'User-Agent': 'nhacte/1.0.0',
+                                  'User-Agent': 'nhac/1.0.0',
                                 },
                                 fit: BoxFit.cover,
                                 placeholder: (context, url) => 

--- a/lib/services/audio_handler.dart
+++ b/lib/services/audio_handler.dart
@@ -4,14 +4,14 @@ import 'package:just_audio/just_audio.dart';
 import '../models/song.dart';
 import '../services/navidrome_api.dart';
 
-class NhacteAudioHandler extends BaseAudioHandler with SeekHandler {
+class NhacAudioHandler extends BaseAudioHandler with SeekHandler {
   final AudioPlayer _player;
   NavidromeApi _api; // Made non-final to allow updates
   List<Song> _queue = [];
   List<String?> _coverArtPaths = []; // Local paths to cached cover art
   int _currentIndex = 0;
   
-  NhacteAudioHandler(this._player, this._api) {
+  NhacAudioHandler(this._player, this._api) {
     _notifyAudioHandlerAboutPlaybackEvents();
     _listenForDurationChanges();
     _listenForCurrentSongIndexChanges();

--- a/lib/services/database_helper.dart
+++ b/lib/services/database_helper.dart
@@ -9,7 +9,7 @@ import '../models/song.dart';
 
 class DatabaseHelper {
   static Database? _database;
-  static const String _databaseName = 'nhacte_cache.db';
+  static const String _databaseName = 'nhac_cache.db';
   static const int _databaseVersion = 1;
 
   static Future<Database> get database async {

--- a/lib/services/navidrome_api.dart
+++ b/lib/services/navidrome_api.dart
@@ -10,7 +10,7 @@ class NavidromeApi {
   final String baseUrl;
   final String username;
   final String password;
-  final String clientName = 'nhacte';
+  final String clientName = 'nhac';
   final String apiVersion = '1.16.1';
   
   // Cache auth params for stable URLs

--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -4,10 +4,10 @@ project(runner LANGUAGES CXX)
 
 # The name of the executable created for the application. Change this to change
 # the on-disk name of your application.
-set(BINARY_NAME "nhacte")
+set(BINARY_NAME "nhac")
 # The unique GTK application identifier for this application. See:
 # https://wiki.gnome.org/HowDoI/ChooseApplicationID
-set(APPLICATION_ID "dev.myyc.nhacte")
+set(APPLICATION_ID "dev.myyc.nhac")
 
 # Explicitly opt in to modern CMake behaviors to avoid warnings with recent
 # versions of CMake.

--- a/linux/runner/my_application.cc
+++ b/linux/runner/my_application.cc
@@ -27,7 +27,7 @@ static void my_application_activate(GApplication* application) {
       GTK_WINDOW(gtk_application_window_new(GTK_APPLICATION(application)));
 
   // Don't use GTK header bar - we'll use a custom window frame from Flutter
-  gtk_window_set_title(window, "nhacte");
+  gtk_window_set_title(window, "nhac");
 
   gtk_window_set_default_size(window, 1280, 720);
 

--- a/macos/Runner.xcodeproj/project.pbxproj
+++ b/macos/Runner.xcodeproj/project.pbxproj
@@ -64,7 +64,7 @@
 		331C80D7294CF71000263BE5 /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
 		333000ED22D3DE5D00554162 /* Warnings.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Warnings.xcconfig; sourceTree = "<group>"; };
 		335BBD1A22A9A15E00E9071D /* GeneratedPluginRegistrant.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GeneratedPluginRegistrant.swift; sourceTree = "<group>"; };
-		33CC10ED2044A3C60003C045 /* nhacte.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "nhacte.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		33CC10ED2044A3C60003C045 /* nhac.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "nhac.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		33CC10F02044A3C60003C045 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		33CC10F22044A3C60003C045 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Assets.xcassets; path = Runner/Assets.xcassets; sourceTree = "<group>"; };
 		33CC10F52044A3C60003C045 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/MainMenu.xib; sourceTree = "<group>"; };
@@ -131,7 +131,7 @@
 		33CC10EE2044A3C60003C045 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				33CC10ED2044A3C60003C045 /* nhacte.app */,
+				33CC10ED2044A3C60003C045 /* nhac.app */,
 				331C80D5294CF71000263BE5 /* RunnerTests.xctest */,
 			);
 			name = Products;
@@ -217,7 +217,7 @@
 			);
 			name = Runner;
 			productName = Runner;
-			productReference = 33CC10ED2044A3C60003C045 /* nhacte.app */;
+			productReference = 33CC10ED2044A3C60003C045 /* nhac.app */;
 			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */
@@ -385,10 +385,10 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = dev.myyc.nhacte.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.myyc.nhac.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/nhacte.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/nhacte";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/nhac.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/nhac";
 			};
 			name = Debug;
 		};
@@ -399,10 +399,10 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = dev.myyc.nhacte.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.myyc.nhac.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/nhacte.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/nhacte";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/nhac.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/nhac";
 			};
 			name = Release;
 		};
@@ -413,10 +413,10 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = dev.myyc.nhacte.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.myyc.nhac.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/nhacte.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/nhacte";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/nhac.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/nhac";
 			};
 			name = Profile;
 		};

--- a/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "33CC10EC2044A3C60003C045"
-               BuildableName = "nhacte.app"
+               BuildableName = "nhac.app"
                BlueprintName = "Runner"
                ReferencedContainer = "container:Runner.xcodeproj">
             </BuildableReference>
@@ -31,7 +31,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "33CC10EC2044A3C60003C045"
-            BuildableName = "nhacte.app"
+            BuildableName = "nhac.app"
             BlueprintName = "Runner"
             ReferencedContainer = "container:Runner.xcodeproj">
          </BuildableReference>
@@ -66,7 +66,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "33CC10EC2044A3C60003C045"
-            BuildableName = "nhacte.app"
+            BuildableName = "nhac.app"
             BlueprintName = "Runner"
             ReferencedContainer = "container:Runner.xcodeproj">
          </BuildableReference>
@@ -83,7 +83,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "33CC10EC2044A3C60003C045"
-            BuildableName = "nhacte.app"
+            BuildableName = "nhac.app"
             BlueprintName = "Runner"
             ReferencedContainer = "container:Runner.xcodeproj">
          </BuildableReference>

--- a/macos/Runner/Configs/AppInfo.xcconfig
+++ b/macos/Runner/Configs/AppInfo.xcconfig
@@ -5,10 +5,10 @@
 // 'flutter create' template.
 
 // The application's name. By default this is also the title of the Flutter window.
-PRODUCT_NAME = nhacte
+PRODUCT_NAME = nhac
 
 // The application's bundle identifier
-PRODUCT_BUNDLE_IDENTIFIER = dev.myyc.nhacte
+PRODUCT_BUNDLE_IDENTIFIER = dev.myyc.nhac
 
 // The copyright displayed in application information
 PRODUCT_COPYRIGHT = Copyright © 2025 dev.myyc. All rights reserved.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,4 +1,4 @@
-name: nhacte
+name: nhac
 description: "A new Flutter project."
 # The following line prevents the package from being accidentally published to
 # pub.dev using `flutter pub publish`. This is preferred for private packages.

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -8,7 +8,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:nhacte/main.dart';
+import 'package:nhac/main.dart';
 
 void main() {
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -1,10 +1,10 @@
 # Project-level configuration.
 cmake_minimum_required(VERSION 3.14)
-project(nhacte LANGUAGES CXX)
+project(nhac LANGUAGES CXX)
 
 # The name of the executable created for the application. Change this to change
 # the on-disk name of your application.
-set(BINARY_NAME "nhacte")
+set(BINARY_NAME "nhac")
 
 # Explicitly opt in to modern CMake behaviors to avoid warnings with recent
 # versions of CMake.

--- a/windows/runner/Runner.rc
+++ b/windows/runner/Runner.rc
@@ -90,12 +90,12 @@ BEGIN
         BLOCK "040904e4"
         BEGIN
             VALUE "CompanyName", "dev.myyc" "\0"
-            VALUE "FileDescription", "nhacte" "\0"
+            VALUE "FileDescription", "nhac" "\0"
             VALUE "FileVersion", VERSION_AS_STRING "\0"
-            VALUE "InternalName", "nhacte" "\0"
+            VALUE "InternalName", "nhac" "\0"
             VALUE "LegalCopyright", "Copyright (C) 2025 dev.myyc. All rights reserved." "\0"
-            VALUE "OriginalFilename", "nhacte.exe" "\0"
-            VALUE "ProductName", "nhacte" "\0"
+            VALUE "OriginalFilename", "nhac.exe" "\0"
+            VALUE "ProductName", "nhac" "\0"
             VALUE "ProductVersion", VERSION_AS_STRING "\0"
         END
     END

--- a/windows/runner/main.cpp
+++ b/windows/runner/main.cpp
@@ -27,7 +27,7 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
   FlutterWindow window(project);
   Win32Window::Point origin(10, 10);
   Win32Window::Size size(1280, 720);
-  if (!window.Create(L"nhacte", origin, size)) {
+  if (!window.Create(L"nhac", origin, size)) {
     return EXIT_FAILURE;
   }
   window.SetQuitOnClose(true);


### PR DESCRIPTION
## Summary
Complete rename of the application from "nhacte" to "nhac" across all platforms and configurations.

## Changes

### Dart/Flutter Code
- Renamed main app class from `NhacteApp` to `NhacApp`
- Renamed audio handler class from `NhacteAudioHandler` to `NhacAudioHandler`
- Updated app title from 'Nhacte' to 'Nhac' in MaterialApp and login screen
- Changed client name in API calls from 'nhacte' to 'nhac'
- Updated database name from `nhacte_cache.db` to `nhac_cache.db`
- Modified package imports in tests from `package:nhacte` to `package:nhac`

### Android
- Changed package name from `dev.myyc.nhacte` to `dev.myyc.nhac`
- Moved MainActivity.kt to new package directory structure
- Updated app label in AndroidManifest.xml
- Modified notification channel ID to use new package name

### iOS/macOS
- Updated bundle identifier from `dev.myyc.nhacte` to `dev.myyc.nhac`
- Changed product name in Xcode configuration files
- Modified all references in .xcodeproj files

### Linux
- Updated binary name and application ID in CMakeLists.txt
- Changed window title in my_application.cc

### Windows
- Updated binary name in CMakeLists.txt
- Changed window title and file descriptions in Runner.rc
- Modified executable name references

### Project Configuration
- Updated `pubspec.yaml` package name
- Modified README.md title

## Test Plan
- [x] Flutter analyze passes
- [x] App builds on all platforms
- [x] Package structure is consistent
- [x] No references to old name remain

## Breaking Changes
- Users will need to uninstall the old app and install the new one
- Database will be recreated (old cache will not be migrated)
- Android package name change means it's treated as a different app

🤖 Generated with [Claude Code](https://claude.ai/code)