### PR TITLE
Add social media story sharing for Android

### DIFF
--- a/lib/screens/now_playing_screen.dart
+++ b/lib/screens/now_playing_screen.dart
@@ -8,6 +8,7 @@ import '../providers/player_provider.dart';
 import '../providers/auth_provider.dart';
 import '../models/artist.dart';
 import '../models/album.dart';
+import '../services/share_service.dart';
 import 'artist_detail_screen.dart';
 import 'album_detail_screen.dart';
 
@@ -23,6 +24,7 @@ class NowPlayingScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final cacheProvider = context.read<CacheProvider>();
+    final shareService = ShareService();
     
     return Consumer<PlayerProvider>(
       builder: (context, playerProvider, child) {
@@ -44,6 +46,23 @@ class NowPlayingScreen extends StatelessWidget {
               icon: const Icon(Icons.arrow_back),
               onPressed: () => Navigator.of(context).pop(),
             ),
+            actions: [
+              if (Platform.isAndroid && song.coverArt != null)
+                IconButton(
+                  icon: const Icon(Icons.share),
+                  onPressed: () {
+                    // Capture theme before sharing
+                    final capturedTheme = InheritedTheme.capture(from: context, to: context);
+                    shareService.shareStoryImage(
+                      context: context,
+                      song: song,
+                      coverArtUrl: cacheProvider.getCoverArtUrl(song.coverArt!, size: 800),
+                      styleType: 'solid',
+                      capturedTheme: capturedTheme,
+                    );
+                  },
+                ),
+            ],
           ),
           body: Padding(
             padding: const EdgeInsets.all(24.0),

--- a/lib/services/share_service.dart
+++ b/lib/services/share_service.dart
@@ -1,0 +1,182 @@
+import 'dart:io';
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:screenshot/screenshot.dart';
+import 'package:share_plus/share_plus.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:google_fonts/google_fonts.dart';
+import '../models/song.dart';
+import '../services/color_extraction_service.dart';
+
+class ShareService {
+  static final ShareService _instance = ShareService._internal();
+  factory ShareService() => _instance;
+  ShareService._internal();
+
+  final ScreenshotController _screenshotController = ScreenshotController();
+  final ColorExtractionService _colorService = ColorExtractionService();
+
+  Future<void> shareStoryImage({
+    required BuildContext context,
+    required Song song,
+    required String coverArtUrl,
+    String? styleType,
+    CapturedThemes? capturedTheme,
+  }) async {
+    try {
+      debugPrint('ShareService: Starting share for song: ${song.title}');
+      debugPrint('ShareService: Cover art URL: $coverArtUrl');
+      
+      // Check if coverArtUrl is valid
+      if (coverArtUrl.isEmpty) {
+        throw Exception('Invalid cover art URL');
+      }
+      
+      final extractedColors = await _colorService.extractColorsFromImage(
+        coverArtUrl,
+        cacheKey: 'share_${song.id}',
+      );
+      debugPrint('ShareService: Colors extracted successfully');
+
+      final widget = _buildStoryWidget(
+        context: context,
+        song: song,
+        coverArtUrl: coverArtUrl,
+        colors: extractedColors,
+        style: styleType ?? 'solid',
+      );
+      debugPrint('ShareService: Widget built successfully');
+
+      // Use captured theme if available, otherwise create a simple wrapper
+      final wrappedWidget = capturedTheme != null
+          ? capturedTheme.wrap(
+              MediaQuery(
+                data: const MediaQueryData(),
+                child: Material(
+                  color: Colors.transparent,
+                  child: widget,
+                ),
+              ),
+            )
+          : MediaQuery(
+              data: const MediaQueryData(),
+              child: Material(
+                color: Colors.transparent,
+                child: widget,
+              ),
+            );
+
+      final image = await _screenshotController.captureFromWidget(
+        wrappedWidget,
+        pixelRatio: 3.0,
+        targetSize: const Size(1080, 1920),
+      );
+      debugPrint('ShareService: Screenshot captured successfully');
+
+      final tempDir = await getTemporaryDirectory();
+      final file = File('${tempDir.path}/nhac_story_${DateTime.now().millisecondsSinceEpoch}.png');
+      await file.writeAsBytes(image);
+      debugPrint('ShareService: File saved to: ${file.path}');
+
+      await Share.shareXFiles(
+        [XFile(file.path)],
+        text: '${song.title} by ${song.artist ?? "Unknown Artist"} 🎵',
+      );
+
+      await Future.delayed(const Duration(seconds: 5));
+      if (await file.exists()) {
+        await file.delete();
+      }
+    } catch (e, stackTrace) {
+      debugPrint('Error sharing story image: $e');
+      debugPrint('Stack trace: $stackTrace');
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Failed to share story')),
+        );
+      }
+    }
+  }
+
+  Widget _buildStoryWidget({
+    required BuildContext context,
+    required Song song,
+    required String coverArtUrl,
+    required ExtractedColors colors,
+    required String style,
+  }) {
+    final backgroundColor = colors.lightBackground;
+    final frameColor = colors.darkBackground;
+    final textColor = colors.darkBackground.computeLuminance() > 0.5 
+        ? Colors.black87 
+        : Colors.white;
+
+    return Container(
+      width: 1080,
+      height: 1920,
+      color: backgroundColor,
+      child: Center(
+        child: Container(
+          width: 700,
+          padding: const EdgeInsets.all(40),
+          decoration: BoxDecoration(
+            color: frameColor,
+            borderRadius: BorderRadius.circular(30),
+            boxShadow: [
+              BoxShadow(
+                color: Colors.black.withOpacity(0.3),
+                blurRadius: 50,
+                offset: const Offset(0, 20),
+              ),
+            ],
+          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Container(
+                width: 600,
+                height: 600,
+                decoration: BoxDecoration(
+                  borderRadius: BorderRadius.circular(20),
+                  image: DecorationImage(
+                    image: CachedNetworkImageProvider(coverArtUrl),
+                    fit: BoxFit.cover,
+                  ),
+                ),
+              ),
+              const SizedBox(height: 40),
+              Text(
+                song.title,
+                style: GoogleFonts.inter(
+                  fontSize: 42,
+                  fontWeight: FontWeight.w700,
+                  color: textColor,
+                  height: 1.2,
+                ),
+                textAlign: TextAlign.center,
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+              ),
+              const SizedBox(height: 12),
+              Text(
+                song.artist ?? 'Unknown Artist',
+                style: GoogleFonts.inter(
+                  fontSize: 32,
+                  fontWeight: FontWeight.w500,
+                  color: textColor.withOpacity(0.8),
+                ),
+                textAlign: TextAlign.center,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+}

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -9,6 +9,7 @@
 #include <bitsdojo_window_linux/bitsdojo_window_plugin.h>
 #include <media_kit_libs_linux/media_kit_libs_linux_plugin.h>
 #include <screen_retriever/screen_retriever_plugin.h>
+#include <url_launcher_linux/url_launcher_plugin.h>
 #include <window_manager/window_manager_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
@@ -21,6 +22,9 @@ void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) screen_retriever_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "ScreenRetrieverPlugin");
   screen_retriever_plugin_register_with_registrar(screen_retriever_registrar);
+  g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
+  url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);
   g_autoptr(FlPluginRegistrar) window_manager_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "WindowManagerPlugin");
   window_manager_plugin_register_with_registrar(window_manager_registrar);

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -6,6 +6,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   bitsdojo_window_linux
   media_kit_libs_linux
   screen_retriever
+  url_launcher_linux
   window_manager
 )
 

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -11,6 +11,7 @@ import bitsdojo_window_macos
 import just_audio
 import path_provider_foundation
 import screen_retriever
+import share_plus
 import shared_preferences_foundation
 import sqflite_darwin
 import window_manager
@@ -22,6 +23,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   JustAudioPlugin.register(with: registry.registrar(forPlugin: "JustAudioPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   ScreenRetrieverPlugin.register(with: registry.registrar(forPlugin: "ScreenRetrieverPlugin"))
+  SharePlusMacosPlugin.register(with: registry.registrar(forPlugin: "SharePlusMacosPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   SqflitePlugin.register(with: registry.registrar(forPlugin: "SqflitePlugin"))
   WindowManagerPlugin.register(with: registry.registrar(forPlugin: "WindowManagerPlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -161,6 +161,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.19.1"
+  cross_file:
+    dependency: transitive
+    description:
+      name: cross_file
+      sha256: "7caf6a750a0c04effbb52a676dce9a4a592e10ad35c34d6d2d0e4811160d5670"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.4+2"
   crypto:
     dependency: "direct main"
     description:
@@ -408,6 +416,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.16.0"
+  mime:
+    dependency: transitive
+    description:
+      name: mime
+      sha256: "41a20518f0cb1256669420fdba0cd90d21561e560ac240f26ef8322e45bb7ed6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
   nested:
     dependency: transitive
     description:
@@ -552,6 +568,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.1.9"
+  screenshot:
+    dependency: "direct main"
+    description:
+      name: screenshot
+      sha256: "63817697a7835e6ce82add4228e15d233b74d42975c143ad8cfe07009fab866b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.0"
+  share_plus:
+    dependency: "direct main"
+    description:
+      name: share_plus
+      sha256: fce43200aa03ea87b91ce4c3ac79f0cecd52e2a7a56c7a4185023c271fbfa6da
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.1.4"
+  share_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: share_plus_platform_interface
+      sha256: cc012a23fc2d479854e6c80150696c4a5f5bb62cb89af4de1c505cf78d0a5d0b
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.2"
   shared_preferences:
     dependency: "direct main"
     description:
@@ -757,6 +797,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.0"
+  url_launcher_linux:
+    dependency: transitive
+    description:
+      name: url_launcher_linux
+      sha256: "4e9ba368772369e3e08f231d2301b4ef72b9ff87c31192ef471b380ef29a4935"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.1"
+  url_launcher_platform_interface:
+    dependency: transitive
+    description:
+      name: url_launcher_platform_interface
+      sha256: "552f8a1e663569be95a8190206a38187b531910283c3e982193e4f2733f01029"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
+  url_launcher_web:
+    dependency: transitive
+    description:
+      name: url_launcher_web
+      sha256: "4bd2b7b4dc4d4d0b94e5babfffbca8eac1a126c7f3d6ecbc1a11013faa3abba2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  url_launcher_windows:
+    dependency: transitive
+    description:
+      name: url_launcher_windows
+      sha256: "3284b6d2ac454cf34f114e1d3319866fdd1e19cdc329999057e44ffe936cfa77"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.4"
   uuid:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -81,6 +81,12 @@ dependencies:
   # Color extraction from images
   palette_generator: ^0.3.3+4
   
+  # Sharing functionality
+  share_plus: ^10.1.2
+  
+  # Screenshot generation
+  screenshot: ^3.0.0
+  
 
 dev_dependencies:
   flutter_test:

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -8,6 +8,8 @@
 
 #include <bitsdojo_window_windows/bitsdojo_window_plugin.h>
 #include <screen_retriever/screen_retriever_plugin.h>
+#include <share_plus/share_plus_windows_plugin_c_api.h>
+#include <url_launcher_windows/url_launcher_windows.h>
 #include <window_manager/window_manager_plugin.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
@@ -15,6 +17,10 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("BitsdojoWindowPlugin"));
   ScreenRetrieverPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("ScreenRetrieverPlugin"));
+  SharePlusWindowsPluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("SharePlusWindowsPluginCApi"));
+  UrlLauncherWindowsRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("UrlLauncherWindows"));
   WindowManagerPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("WindowManagerPlugin"));
 }

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -5,6 +5,8 @@
 list(APPEND FLUTTER_PLUGIN_LIST
   bitsdojo_window_windows
   screen_retriever
+  share_plus
+  url_launcher_windows
   window_manager
 )
 


### PR DESCRIPTION
## Summary
- Added share button to Now Playing screen (Android only) for sharing song stories to social media
- Generates Instagram/Snapchat-style story images with album artwork
- Uses extracted colors from album art for dynamic backgrounds

## Features
- **Story Image Generation**: Creates a 1080x1920 story-format image with:
  - Album cover art in a rounded frame
  - Song title and artist name
  - Dynamic colors extracted from the album art (darker color for frame, lighter for background)
  - Clean, Spotify-inspired design

- **Android-only Implementation**: Share button appears only on Android devices in the top-right corner of the Now Playing screen

- **Color Extraction**: Leverages existing `ColorExtractionService` to create visually cohesive story cards

## Technical Details
- Added `share_plus` and `screenshot` packages for sharing and image generation
- Created new `ShareService` to handle story image generation and sharing
- Fixed screenshot widget rendering issues with proper theme context capture

## Test Plan
- [x] Test share button appears only on Android
- [x] Verify story image generates correctly with album art
- [x] Confirm sharing works with Instagram, Snapchat, and other story-capable apps
- [x] Test with songs that have missing album art
- [x] Verify color extraction produces good contrast

🤖 Generated with [Claude Code](https://claude.ai/code)