### PR TITLE
Fix audio playback queue navigation and unify platform behavior

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -19,7 +19,8 @@ import 'services/audio_handler.dart';
 import 'services/navidrome_api.dart';
 import 'theme/app_theme.dart';
 
-late NhacAudioHandler? audioHandler;
+late BaseAudioHandler? audioHandler;
+late NhacAudioHandler? actualAudioHandler;
 late AudioPlayer globalAudioPlayer;
 
 void main() async {
@@ -46,11 +47,14 @@ void main() async {
       username: '',
       password: '',
     );
+    // Create the actual handler
+    actualAudioHandler = NhacAudioHandler(
+      globalAudioPlayer, // Use the shared player instance
+      dummyApi, // This will be properly set later in PlayerProvider
+    );
+    
     audioHandler = await AudioService.init(
-      builder: () => NhacAudioHandler(
-        globalAudioPlayer, // Use the shared player instance
-        dummyApi, // This will be properly set later in PlayerProvider
-      ),
+      builder: () => actualAudioHandler!,
       config: const AudioServiceConfig(
         androidNotificationChannelId: 'dev.myyc.nhac.channel.audio',
         androidNotificationChannelName: 'Music playback',
@@ -58,7 +62,7 @@ void main() async {
         androidNotificationOngoing: false,
         androidStopForegroundOnPause: false, // Keep service alive during pause
       ),
-    ) as NhacAudioHandler;
+    );
   } else {
     audioHandler = null;
   }

--- a/lib/screens/search_screen.dart
+++ b/lib/screens/search_screen.dart
@@ -154,19 +154,20 @@ class _SearchScreenState extends State<SearchScreen> {
               if (songIndex != -1) {
                 playerProvider.playQueue(albumSongs, startIndex: songIndex);
               } else {
-                // If song not found in album, just play the song
-                playerProvider.playSong(song);
+                // If song not found in album, just play as single track
+                playerProvider.playQueue([song], startIndex: 0);
               }
             } else {
-              playerProvider.playSong(song);
+              // Album has no songs, just play as single track
+              playerProvider.playQueue([song], startIndex: 0);
             }
           } catch (e) {
-            // If loading album fails, just play the single song
-            playerProvider.playSong(song);
+            // If loading album fails, just play as single track
+            playerProvider.playQueue([song], startIndex: 0);
           }
         } else {
-          // No album info, just play the single song
-          playerProvider.playSong(song);
+          // No album info, just play as single track
+          playerProvider.playQueue([song], startIndex: 0);
         }
       },
     );


### PR DESCRIPTION
## Summary
- Fixed critical bug where next/previous buttons weren't working correctly
- Unified audio playback behavior across all platforms (Linux, Android, Windows, macOS)
- Removed deprecated ConcatenatingAudioSource in favor of modern setAudioSources API

## Changes
- **Removed `playSong` method** - Everything now uses `playQueue` with full album/list for consistent behavior
- **Fixed queue restoration** - Was incorrectly resetting to single song instead of full queue
- **Unified platform code** - Removed Linux/Android branching, all platforms now use same audio handling
- **Fixed index tracking** - Proper mediaItem listener for UI updates
- **Added navigation state** - `canGoNext` and `canGoPrevious` getters for UI button states
- **Simplified navigation** - Using built-in player methods with proper playlist support

## Test Plan
- [x] Play album from any track - verify full album is loaded
- [x] Next button advances to next track
- [x] Previous button restarts track if >3 seconds in, goes to previous if <3 seconds
- [x] Navigation preserves pause state
- [x] Track metadata updates correctly when navigating
- [x] Works consistently on Linux and Android

## Fixes
Fixes issue where "next" and "previous" buttons were not working properly and track metadata wasn't updating when navigating between tracks.

🤖 Generated with [Claude Code](https://claude.ai/code)