### PR TITLE
Improve social share image colors with vibrant backgrounds

### DIFF
--- a/lib/services/share_service.dart
+++ b/lib/services/share_service.dart
@@ -108,9 +108,9 @@ class ShareService {
     required ExtractedColors colors,
     required String style,
   }) {
-    final backgroundColor = colors.lightBackground;
-    final frameColor = colors.darkBackground;
-    final textColor = colors.darkBackground.computeLuminance() > 0.5 
+    final backgroundColor = colors.getSocialShareBackground();
+    final frameColor = colors.darkSurface;
+    final textColor = colors.darkSurface.computeLuminance() > 0.5 
         ? Colors.black87 
         : Colors.white;
 


### PR DESCRIPTION
## Summary
- Enhanced social share images to use more vibrant colors extracted from album art
- Share images now better represent the album's color palette instead of defaulting to pale/white backgrounds

## Changes
- **Background**: Now uses the accent color from album art with minimal adjustment (65-85% lightness)
- **Frame**: Switched from `darkBackground` to `darkSurface` for more vibrant dark tones
- **Color extraction**: Enhanced to better preserve album art character with improved saturation handling

## Technical Details
- Added `getSocialShareBackground()` method to `ExtractedColors` class
- Updated `_createLightSurface()` to maintain higher saturation (55% instead of 40%)
- Modified share service to use the new vibrant color scheme

## Test Plan
- [x] Test share functionality with various album art colors
- [x] Verify text remains readable on both light and dark album art
- [x] Confirm colors accurately represent the album artwork

🤖 Generated with [Claude Code](https://claude.ai/code)