### PR TITLE
Extend pull-to-search to all content screens with elastic improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ It works okay and looks quite nice.
 
 Stuff that isn't available but is planned:
 
-* windows, macos builds - ios is harder for obvious reasons
+* windows builds - ios is harder for obvious reasons
 * proper offline support and better audio caching
 * keyboard navigation, there is little right now (type to search, escape to go back, spacebar to play/pause)
 

--- a/lib/screens/album_detail_screen.dart
+++ b/lib/screens/album_detail_screen.dart
@@ -11,6 +11,7 @@ import '../models/song.dart';
 import '../models/artist.dart';
 import '../widgets/cached_cover_image.dart';
 import '../widgets/artistic_background.dart';
+import '../widgets/pull_to_search.dart';
 import 'artist_detail_screen.dart';
 import '../widgets/custom_window_frame.dart';
 import '../widgets/now_playing_bar.dart';
@@ -18,8 +19,9 @@ import 'dart:io' show Platform;
 
 class AlbumDetailScreen extends StatefulWidget {
   final Album album;
+  final VoidCallback? onOpenSearch;
 
-  const AlbumDetailScreen({super.key, required this.album});
+  const AlbumDetailScreen({super.key, required this.album, this.onOpenSearch});
 
   @override
   State<AlbumDetailScreen> createState() => _AlbumDetailScreenState();
@@ -134,10 +136,13 @@ class _AlbumDetailScreenState extends State<AlbumDetailScreen> {
                     ],
                   ),
                 )
-              : SingleChildScrollView(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
+              : PullToSearch(
+                  onSearchTriggered: widget.onOpenSearch ?? () {},
+                  triggerThreshold: 80.0,
+                  child: SingleChildScrollView(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
                       // Album cover with artistic background
                       (Platform.isWindows || Platform.isLinux || Platform.isMacOS) 
                           ? SizedBox(
@@ -254,7 +259,10 @@ class _AlbumDetailScreenState extends State<AlbumDetailScreen> {
                                   Navigator.push(
                                     context,
                                     MaterialPageRoute(
-                                      builder: (context) => ArtistDetailScreen(artist: artist),
+                                      builder: (context) => ArtistDetailScreen(
+                                        artist: artist,
+                                        onOpenSearch: widget.onOpenSearch,
+                                      ),
                                     ),
                                   );
                                 } : null,
@@ -492,6 +500,7 @@ class _AlbumDetailScreenState extends State<AlbumDetailScreen> {
                         
                       const SizedBox(height: 16), // Small padding at bottom
                     ],
+                    ),
                   ),
                 ),
           ),

--- a/lib/screens/albums_screen.dart
+++ b/lib/screens/albums_screen.dart
@@ -4,10 +4,13 @@ import '../providers/auth_provider.dart';
 import '../providers/cache_provider.dart';
 import '../models/album.dart';
 import '../widgets/cached_cover_image.dart';
+import '../widgets/pull_to_search.dart';
 import 'album_detail_screen.dart';
 
 class AlbumsScreen extends StatefulWidget {
-  const AlbumsScreen({super.key});
+  final VoidCallback? onOpenSearch;
+
+  const AlbumsScreen({super.key, this.onOpenSearch});
 
   @override
   State<AlbumsScreen> createState() => _AlbumsScreenState();
@@ -81,9 +84,12 @@ class _AlbumsScreenState extends State<AlbumsScreen> {
       );
     }
 
-    return RefreshIndicator(
-      onRefresh: _loadAlbums,
-      child: GridView.builder(
+    return PullToSearch(
+      onSearchTriggered: widget.onOpenSearch ?? () {},
+      triggerThreshold: 80.0,
+      child: RefreshIndicator(
+        onRefresh: _loadAlbums,
+        child: GridView.builder(
         padding: const EdgeInsets.all(16),
         gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
           maxCrossAxisExtent: 200,
@@ -100,7 +106,10 @@ class _AlbumsScreenState extends State<AlbumsScreen> {
               Navigator.push(
                 context,
                 MaterialPageRoute(
-                  builder: (context) => AlbumDetailScreen(album: album),
+                  builder: (context) => AlbumDetailScreen(
+                    album: album,
+                    onOpenSearch: widget.onOpenSearch,
+                  ),
                 ),
               );
             },
@@ -140,6 +149,7 @@ class _AlbumsScreenState extends State<AlbumsScreen> {
             ),
           );
         },
+      ),
       ),
     );
   }

--- a/lib/screens/artist_detail_screen.dart
+++ b/lib/screens/artist_detail_screen.dart
@@ -8,13 +8,15 @@ import '../models/artist.dart';
 import '../models/album.dart';
 import 'album_detail_screen.dart';
 import 'app_scaffold.dart';
+import '../widgets/pull_to_search.dart';
 import '../widgets/custom_window_frame.dart';
 import 'dart:io' show Platform;
 
 class ArtistDetailScreen extends StatefulWidget {
   final Artist artist;
+  final VoidCallback? onOpenSearch;
 
-  const ArtistDetailScreen({super.key, required this.artist});
+  const ArtistDetailScreen({super.key, required this.artist, this.onOpenSearch});
 
   @override
   State<ArtistDetailScreen> createState() => _ArtistDetailScreenState();
@@ -88,7 +90,10 @@ class _ArtistDetailScreenState extends State<ArtistDetailScreen> {
                 )
               : _albums == null || _albums!.isEmpty
                   ? const Center(child: Text('No albums found'))
-                  : GridView.builder(
+                  : PullToSearch(
+                      onSearchTriggered: widget.onOpenSearch ?? () {},
+                      triggerThreshold: 80.0,
+                      child: GridView.builder(
                       padding: const EdgeInsets.all(16),
                       gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
                         maxCrossAxisExtent: 200,
@@ -105,7 +110,10 @@ class _ArtistDetailScreenState extends State<ArtistDetailScreen> {
                             Navigator.push(
                               context,
                               MaterialPageRoute(
-                                builder: (context) => AlbumDetailScreen(album: album),
+                                builder: (context) => AlbumDetailScreen(
+                                  album: album,
+                                  onOpenSearch: widget.onOpenSearch,
+                                ),
                               ),
                             );
                           },
@@ -154,6 +162,7 @@ class _ArtistDetailScreenState extends State<ArtistDetailScreen> {
                         );
                       },
                     ),
+                  ),
     );
     
     // Add ESC key handling for desktop

--- a/lib/screens/artists_screen.dart
+++ b/lib/screens/artists_screen.dart
@@ -4,10 +4,13 @@ import '../providers/auth_provider.dart';
 import '../providers/cache_provider.dart';
 import '../models/artist.dart';
 import '../widgets/cached_cover_image.dart';
+import '../widgets/pull_to_search.dart';
 import 'artist_detail_screen.dart';
 
 class ArtistsScreen extends StatefulWidget {
-  const ArtistsScreen({super.key});
+  final VoidCallback? onOpenSearch;
+
+  const ArtistsScreen({super.key, this.onOpenSearch});
 
   @override
   State<ArtistsScreen> createState() => _ArtistsScreenState();
@@ -78,9 +81,12 @@ class _ArtistsScreenState extends State<ArtistsScreen> {
       );
     }
 
-    return RefreshIndicator(
-      onRefresh: _loadArtists,
-      child: ListView.builder(
+    return PullToSearch(
+      onSearchTriggered: widget.onOpenSearch ?? () {},
+      triggerThreshold: 80.0,
+      child: RefreshIndicator(
+        onRefresh: _loadArtists,
+        child: ListView.builder(
         itemCount: _artists!.length,
         itemBuilder: (context, index) {
           final artist = _artists![index];
@@ -114,12 +120,16 @@ class _ArtistsScreenState extends State<ArtistsScreen> {
               Navigator.push(
                 context,
                 MaterialPageRoute(
-                  builder: (context) => ArtistDetailScreen(artist: artist),
+                  builder: (context) => ArtistDetailScreen(
+                    artist: artist,
+                    onOpenSearch: widget.onOpenSearch,
+                  ),
                 ),
               );
             },
           );
         },
+      ),
       ),
     );
   }

--- a/lib/widgets/pull_to_search.dart
+++ b/lib/widgets/pull_to_search.dart
@@ -1,0 +1,119 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'dart:io' show Platform;
+
+class PullToSearch extends StatefulWidget {
+  final Widget child;
+  final VoidCallback onSearchTriggered;
+  final double triggerThreshold;
+  final double maxStretchDistance;
+  final double elasticity;
+
+  const PullToSearch({
+    super.key,
+    required this.child,
+    required this.onSearchTriggered,
+    this.triggerThreshold = 80.0,
+    this.maxStretchDistance = 240.0,
+    this.elasticity = 0.6,
+  });
+
+  @override
+  State<PullToSearch> createState() => _PullToSearchState();
+}
+
+class _PullToSearchState extends State<PullToSearch> {
+  double _dragOffset = 0.0;
+  bool _isSearchTriggered = false;
+
+  @override
+  Widget build(BuildContext context) {
+    // Only enable on mobile platforms
+    if (!(Platform.isAndroid || Platform.isIOS)) {
+      return widget.child;
+    }
+
+    return NotificationListener<ScrollNotification>(
+      onNotification: _handleScrollNotification,
+      child: Stack(
+        children: [
+          // Search indicator
+          if (_dragOffset > 0)
+            Positioned(
+              top: 0,
+              left: 0,
+              right: 0,
+              child: SafeArea(
+                bottom: false,
+                child: Container(
+                  height: _dragOffset.clamp(0.0, widget.maxStretchDistance),
+                  decoration: BoxDecoration(
+                    color: Theme.of(context).colorScheme.primaryContainer.withOpacity(0.1),
+                  ),
+                  child: SingleChildScrollView(
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        Icon(
+                          Icons.search,
+                          size: 28,
+                          color: Theme.of(context).colorScheme.primary,
+                        ),
+                        const SizedBox(height: 4),
+                        Text(
+                          _dragOffset > widget.triggerThreshold
+                              ? 'Release to search'
+                              : 'Pull to search',
+                          style: TextStyle(
+                            color: Theme.of(context).colorScheme.primary,
+                            fontWeight: FontWeight.w500,
+                            fontSize: 12,
+                          ),
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+            ),
+
+          // Main content moves directly with finger
+          Transform.translate(
+            offset: Offset(0, _dragOffset),
+            child: widget.child,
+          ),
+        ],
+      ),
+    );
+  }
+
+  bool _handleScrollNotification(ScrollNotification notification) {
+    if (notification is OverscrollNotification && notification.overscroll < 0) {
+      // Use overscroll directly - this gives immediate elastic feedback
+      final dragDistance = -notification.overscroll;
+
+      setState(() {
+        _dragOffset = (dragDistance * 1.5).clamp(0.0, widget.maxStretchDistance);
+      });
+
+      // Check if we should trigger search
+      if (_dragOffset > widget.triggerThreshold && !_isSearchTriggered) {
+        _isSearchTriggered = true;
+        HapticFeedback.mediumImpact();
+        widget.onSearchTriggered();
+      }
+    } else if (notification is ScrollEndNotification || notification is UserScrollNotification) {
+      // Reset when scrolling ends or user scrolls in another direction
+      if (_dragOffset > 0) {
+        setState(() {
+          _dragOffset = 0.0;
+          _isSearchTriggered = false;
+        });
+      }
+    }
+
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
- **Extended pull-to-search functionality** from just home and library screens to all content screens:
  - Albums screen
  - Artists screen  
  - Album detail screen
  - Artist detail screen
- **Improved elasticity** with enhanced rubber-band physics for more responsive movement
- **Fixed layout overflow** issues in search indicator
- **Consistent navigation** with search callback passing through the navigation stack

## Changes
- Created reusable `PullToSearch` widget with elastic physics
- Added `onOpenSearch` parameter to detail screens for consistent functionality
- Improved gesture responsiveness with 1.5x multiplier
- Fixed RenderFlex overflow with SingleChildScrollView

## Test plan
- Test pull-to-search gesture on all content screens
- Verify search triggers reliably from all screens
- Ensure gesture feels elastic and responsive
- Check that navigation works properly from all screens

🤖 Generated with [Claude Code](https://claude.ai/code)