### PR TITLE
Release v1.2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,12 @@ on:
     branches: [ main, master ]
   workflow_dispatch:
 
+# Opt into Node 24 for JavaScript actions ahead of the June 2026 default
+# switch, silencing the Node 20 deprecation warning without bumping
+# individual action majors.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   test:
     name: Run Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,25 @@ jobs:
       - name: Get dependencies
         run: flutter pub get
 
+      - name: Decode release keystore
+        env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+        run: |
+          if [ -z "$ANDROID_KEYSTORE_BASE64" ]; then
+            echo "ANDROID_KEYSTORE_BASE64 secret missing — APK will be debug-signed"
+            exit 0
+          fi
+          echo "$ANDROID_KEYSTORE_BASE64" | base64 -d > android/app/release.jks
+          cat > android/key.properties <<EOF
+          storeFile=release.jks
+          storePassword=$ANDROID_KEYSTORE_PASSWORD
+          keyAlias=$ANDROID_KEY_ALIAS
+          keyPassword=$ANDROID_KEY_PASSWORD
+          EOF
+
       - name: Build Android APK
         run: flutter build apk --release
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,7 @@ jobs:
           sudo apt-get install -y \
             clang cmake ninja-build pkg-config \
             libgtk-3-dev liblzma-dev libstdc++-12-dev \
+            libmpv-dev \
             flatpak flatpak-builder
 
       - name: Setup Flatpak

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,7 @@ repo/
 
 # Android build artifacts
 android/build/
+
+# Local backup of release signing material (mirrors the GitHub Secrets used
+# by CI). Lose these and you can never upgrade installed APKs in place.
+/secrets/

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -1,8 +1,20 @@
+import java.util.Properties
+import java.io.FileInputStream
+
 plugins {
     id("com.android.application")
     id("kotlin-android")
     // The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.
     id("dev.flutter.flutter-gradle-plugin")
+}
+
+// Load release signing config from android/key.properties if present. The file
+// is gitignored; CI populates it from GitHub secrets before building. When
+// missing (e.g. local debug runs), we fall back to the debug signing key.
+val keystoreProperties = Properties()
+val keystorePropertiesFile = rootProject.file("key.properties")
+if (keystorePropertiesFile.exists()) {
+    keystoreProperties.load(FileInputStream(keystorePropertiesFile))
 }
 
 android {
@@ -30,11 +42,24 @@ android {
         versionName = flutter.versionName
     }
 
+    signingConfigs {
+        create("release") {
+            if (keystorePropertiesFile.exists()) {
+                keyAlias = keystoreProperties["keyAlias"] as String
+                keyPassword = keystoreProperties["keyPassword"] as String
+                storeFile = file(keystoreProperties["storeFile"] as String)
+                storePassword = keystoreProperties["storePassword"] as String
+            }
+        }
+    }
+
     buildTypes {
         release {
-            // TODO: Add your own signing config for the release build.
-            // Signing with the debug keys for now, so `flutter run --release` works.
-            signingConfig = signingConfigs.getByName("debug")
+            signingConfig = if (keystorePropertiesFile.exists()) {
+                signingConfigs.getByName("release")
+            } else {
+                signingConfigs.getByName("debug")
+            }
             // Disable shrinking to keep notification icons
             isShrinkResources = false
             isMinifyEnabled = false

--- a/dev.myyc.nhac.yaml
+++ b/dev.myyc.nhac.yaml
@@ -4,8 +4,6 @@ runtime-version: "25.08"
 sdk: org.freedesktop.Sdk
 command: nhac
 finish-args:
-  # Tell our FFI bindings where to find libmpv
-  - --env=LIBMPV_LIBRARY_PATH=/app/lib/libmpv.so
   # Network access for streaming
   - --share=network
   # Audio playback
@@ -38,8 +36,8 @@ modules:
     buildsystem: meson
     sources:
       - type: archive
-        url: https://gitlab.freedesktop.org/pipewire/pipewire/-/archive/1.6.2/pipewire-1.6.2.tar.gz
-        sha256: 2014c187fccdd6d245585be4eda7dabd781dcddd921604c40ab015bba6cb042d
+        url: https://gitlab.freedesktop.org/pipewire/pipewire/-/archive/1.6.3/pipewire-1.6.3.tar.gz
+        sha256: 93db72dc06768db548d48ae2b8e96e7c299c89a47f5c4426f152221aa90b0f2d
     config-opts:
       - --libdir=lib
       - -Dalsa=enabled

--- a/lib/audio/mpv/bindings.dart
+++ b/lib/audio/mpv/bindings.dart
@@ -324,43 +324,17 @@ class LibMpv {
         .asFunction();
   }
 
-  /// Load libmpv from system or custom path
-  static LibMpv? load([String? path]) {
-    final lib = _loadLibrary(path);
-    if (lib == null) return null;
-    return LibMpv._(lib);
-  }
-
-  static DynamicLibrary? _loadLibrary(String? customPath) {
-    // Try custom path first
-    if (customPath != null) {
-      try {
-        return DynamicLibrary.open(customPath);
-      } catch (_) {}
+  /// Resolve libmpv symbols from the running process. The host runner is
+  /// linked against libmpv at build time, so the dynamic linker has already
+  /// loaded libmpv.so.2 by the time Dart code runs.
+  static LibMpv? load() {
+    try {
+      return LibMpv._(DynamicLibrary.process());
+    } catch (e) {
+      // ignore: avoid_print
+      print('[LibMpv] DynamicLibrary.process() failed: $e');
+      return null;
     }
-
-    // Try environment variable
-    final envPath = Platform.environment['LIBMPV_LIBRARY_PATH'];
-    if (envPath != null) {
-      try {
-        return DynamicLibrary.open(envPath);
-      } catch (_) {}
-    }
-
-    // Platform-specific library names
-    final names = Platform.isWindows
-        ? ['libmpv-2.dll', 'mpv-2.dll', 'mpv-1.dll']
-        : Platform.isLinux
-            ? ['libmpv.so', 'libmpv.so.2', 'libmpv.so.1']
-            : <String>[];
-
-    for (final name in names) {
-      try {
-        return DynamicLibrary.open(name);
-      } catch (_) {}
-    }
-
-    return null;
   }
 
   /// Get error message for error code

--- a/lib/audio/mpv/mpv_player.dart
+++ b/lib/audio/mpv/mpv_player.dart
@@ -59,6 +59,10 @@ class MpvPlayer {
   bool _buffering = false;
   double _volume = 1.0;
 
+  // Resolved when mpv emits fileLoaded after a load() call. Used to defer
+  // post-load seeks until mpv is actually ready to handle them.
+  Completer<void>? _fileLoadedCompleter;
+
   /// Stream of player state changes
   Stream<MpvPlayerState> get stateStream => _stateController.stream;
 
@@ -99,22 +103,24 @@ class MpvPlayer {
   bool get isInitialized => _initialized;
 
   /// Initialize the player
-  Future<bool> initialize([String? libmpvPath]) async {
+  Future<bool> initialize() async {
     if (_initialized) return true;
     if (_disposed) return false;
 
     // Set C locale for numeric formatting (required by mpv)
     setNumericLocaleToC();
 
-    _mpv = LibMpv.load(libmpvPath);
+    _mpv = LibMpv.load();
     if (_mpv == null) {
-      _errorController.add(MpvPlayerError(-1, 'Failed to load libmpv'));
+      _errorController.add(MpvPlayerError(-1, 'Failed to resolve libmpv symbols'));
       return false;
     }
 
     _ctx = _mpv!.mpvCreate();
     if (_ctx == null || _ctx == nullptr) {
       _errorController.add(MpvPlayerError(-2, 'Failed to create mpv context'));
+      // ignore: avoid_print
+      print('[MpvPlayer] mpv_create() returned null');
       return false;
     }
 
@@ -138,6 +144,8 @@ class MpvPlayer {
     if (result < 0) {
       final error = _mpv!.getErrorString(result);
       _errorController.add(MpvPlayerError(result, 'Init failed: $error'));
+      // ignore: avoid_print
+      print('[MpvPlayer] mpv_initialize() failed: $error (code $result)');
       _mpv!.mpvTerminateDestroy(_ctx!);
       _ctx = null;
       return false;
@@ -229,10 +237,21 @@ class MpvPlayer {
         case 'pause':
           if (message.value is bool) {
             final paused = message.value as bool;
-            if (paused && _state == MpvPlayerState.playing) {
-              _updateState(MpvPlayerState.paused);
-            } else if (!paused && _state == MpvPlayerState.paused) {
-              _updateState(MpvPlayerState.playing);
+            // Mirror mpv's pause flag onto our state. Cover transitions from
+            // ready/loading too — autoPlay loads land us in `ready` and only
+            // a pause=false event marks the actual start of playback.
+            if (paused) {
+              if (_state == MpvPlayerState.playing ||
+                  _state == MpvPlayerState.ready ||
+                  _state == MpvPlayerState.loading) {
+                _updateState(MpvPlayerState.paused);
+              }
+            } else {
+              if (_state == MpvPlayerState.paused ||
+                  _state == MpvPlayerState.ready ||
+                  _state == MpvPlayerState.loading) {
+                _updateState(MpvPlayerState.playing);
+              }
             }
           }
         case 'eof-reached':
@@ -260,7 +279,16 @@ class MpvPlayer {
           }
       }
     } else if (message is _FileLoadedEvent) {
-      _updateState(MpvPlayerState.ready);
+      // Only mark ready if we're still in the loading phase. load() may have
+      // already moved us to playing/paused based on the autoPlay intent;
+      // don't override that here.
+      if (_state == MpvPlayerState.loading) {
+        _updateState(MpvPlayerState.ready);
+      }
+      // Unblock any load() call waiting to seek post-load.
+      if (_fileLoadedCompleter != null && !_fileLoadedCompleter!.isCompleted) {
+        _fileLoadedCompleter!.complete();
+      }
     } else if (message is _EndFileEvent) {
       if (message.reason == MpvEndFileReason.eof) {
         _updateState(MpvPlayerState.completed);
@@ -284,31 +312,57 @@ class MpvPlayer {
     }
   }
 
-  /// Load and play a URL or file path
-  Future<void> load(String uri, {bool autoPlay = true}) async {
+  /// Load and play a URL or file path. If [startPosition] is provided, the
+  /// player will seek to that offset once mpv has actually loaded the file
+  /// (waiting on the FileLoaded event — sending a seek before then is
+  /// unreliable for HTTP-streamed sources).
+  Future<void> load(String uri, {bool autoPlay = true, Duration? startPosition}) async {
     if (!_initialized || _ctx == null) return;
 
     _updateState(MpvPlayerState.loading);
-    _position = Duration.zero;
+    _position = startPosition ?? Duration.zero;
     _duration = null;
     _positionController.add(_position);
     _durationController.add(null);
 
-    // If not auto-playing, set pause before loading
-    if (!autoPlay) {
+    // Stay paused until the seek has been issued, so playback doesn't briefly
+    // start at 0 before jumping. Then unpause for autoPlay.
+    final hasStart = startPosition != null && startPosition.inMilliseconds > 0;
+    if (hasStart || !autoPlay) {
       await _setProperty('pause', 'yes');
     }
 
+    _fileLoadedCompleter = Completer<void>();
     await _command(['loadfile', uri, 'replace']);
 
-    // If auto-playing, ensure we're not paused
+    if (hasStart) {
+      // Wait for mpv to actually load the file before seeking. Bail after
+      // a short timeout so we don't hang forever on a bad URL.
+      try {
+        await _fileLoadedCompleter!.future
+            .timeout(const Duration(seconds: 8));
+        final secs = startPosition.inMilliseconds / 1000.0;
+        await _command(['seek', secs.toString(), 'absolute']);
+      } catch (_) {
+        // Timed out; carry on without the seek.
+      }
+    }
+
     if (autoPlay) {
+      // Setting pause=no when it was already no (default) doesn't emit a
+      // property-change event, so we'd never leave `ready`. Drive the state
+      // optimistically; an endFile(error) event will roll us back if loading
+      // fails.
       await _setProperty('pause', 'no');
+      _updateState(MpvPlayerState.playing);
+    } else {
+      _updateState(MpvPlayerState.paused);
     }
   }
 
   /// Start or resume playback
   Future<void> play() async {
+    print('[MpvPlayer] play() called, state=$_state, initialized=$_initialized');
     if (!_initialized || _ctx == null) return;
     await _setProperty('pause', 'no');
     _updateState(MpvPlayerState.playing);
@@ -316,6 +370,7 @@ class MpvPlayer {
 
   /// Pause playback
   Future<void> pause() async {
+    print('[MpvPlayer] pause() called, state=$_state');
     if (!_initialized || _ctx == null) return;
     await _setProperty('pause', 'yes');
     _updateState(MpvPlayerState.paused);
@@ -343,9 +398,12 @@ class MpvPlayer {
 
   /// Seek to position
   Future<void> seek(Duration position) async {
+    print('[MpvPlayer] seek($position) called, state=$_state');
     if (!_initialized || _ctx == null) return;
     final seconds = position.inMilliseconds / 1000.0;
-    await _setProperty('time-pos', seconds.toString());
+    // Use the seek command (absolute) — more reliable than setting time-pos
+    // for HTTP-streamed sources where mpv must coordinate cache seeks.
+    await _command(['seek', seconds.toString(), 'absolute']);
   }
 
   /// Seek by offset

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -25,7 +25,7 @@ import 'services/notification_service.dart';
 import 'dart:async';
 
 late BaseAudioHandler? audioHandler;
-late NhacAudioHandler? actualAudioHandler;
+NhacAudioHandler? actualAudioHandler;
 late AudioPlayer globalAudioPlayer;
 MpvPlayer? globalMpvPlayer; // Used on Linux/Windows instead of just_audio
 bool _isCleanedUp = false;
@@ -81,8 +81,6 @@ Future<void> _runEarlyMigrations() async {
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
-  print('[Main] Starting app...');
-
   // Initialize database first (needed for migration check)
   try {
     await DatabaseHelper.database;
@@ -96,13 +94,17 @@ void main() async {
   // On Linux/Windows, use our custom MpvPlayer instead of just_audio + media_kit
   // This avoids the OSC property issue with audio-only mpv builds
   if (Platform.isLinux || Platform.isWindows) {
-    print('[Main] Initializing MpvPlayer for ${Platform.operatingSystem}...');
     globalMpvPlayer = MpvPlayer();
-    final initialized = await globalMpvPlayer!.initialize();
+    bool initialized = false;
+    try {
+      initialized = await globalMpvPlayer!.initialize();
+    } catch (e, st) {
+      print('[Main] MpvPlayer init threw: $e\n$st');
+    }
     if (initialized) {
-      print('[Main] MpvPlayer initialized successfully');
+      print('[Main] MpvPlayer ready');
     } else {
-      print('[Main] MpvPlayer initialization failed, falling back to just_audio');
+      print('[Main] MpvPlayer init failed — playback will not work on this platform');
       globalMpvPlayer = null;
     }
 
@@ -293,18 +295,12 @@ class _AuthWrapperState extends State<AuthWrapper> with WidgetsBindingObserver {
       case AppLifecycleState.paused:
       case AppLifecycleState.inactive:
       case AppLifecycleState.hidden:
-        // App going to background - update foreground state
-        debugPrint('[Main] App backgrounded');
         activityCoordinator.setForegroundState(false);
         break;
       case AppLifecycleState.resumed:
-        // App coming to foreground - update foreground state
-        debugPrint('[Main] App resumed');
         activityCoordinator.setForegroundState(true);
         break;
       case AppLifecycleState.detached:
-        // App is being terminated - clean up resources
-        debugPrint('[Main] App detached - cleaning up');
         _cleanupBeforeExit();
         break;
     }
@@ -332,7 +328,6 @@ class _AuthWrapperState extends State<AuthWrapper> with WidgetsBindingObserver {
     if (_isCleanedUp) return;
     _isCleanedUp = true;
 
-    debugPrint('[Main] Cleaning up before exit...');
 
     // Stop the global audio player immediately to prevent hanging
     // Skip on Linux/Windows where we use MpvPlayer (just_audio triggers media_kit errors)
@@ -355,7 +350,6 @@ class _AuthWrapperState extends State<AuthWrapper> with WidgetsBindingObserver {
       }
     }
 
-    debugPrint('[Main] Cleanup complete');
   }
 
   @override

--- a/lib/models/lyrics.dart
+++ b/lib/models/lyrics.dart
@@ -1,0 +1,66 @@
+class LyricsLine {
+  final Duration? start;
+  final String text;
+
+  LyricsLine({this.start, required this.text});
+}
+
+class Lyrics {
+  final bool synced;
+  final String? lang;
+  final String? displayArtist;
+  final String? displayTitle;
+  final List<LyricsLine> lines;
+
+  Lyrics({
+    required this.synced,
+    this.lang,
+    this.displayArtist,
+    this.displayTitle,
+    required this.lines,
+  });
+
+  bool get isEmpty => lines.isEmpty || lines.every((l) => l.text.trim().isEmpty);
+
+  /// Parse an OpenSubsonic `structuredLyrics` entry.
+  factory Lyrics.fromStructured(Map<String, dynamic> json) {
+    final synced = json['synced'] == true;
+    final linesJson = (json['line'] as List?) ?? const [];
+    final lines = <LyricsLine>[];
+    for (final l in linesJson) {
+      if (l is! Map) continue;
+      final value = (l['value'] ?? '').toString();
+      Duration? start;
+      final rawStart = l['start'];
+      if (synced && rawStart != null) {
+        final ms = rawStart is int
+            ? rawStart
+            : int.tryParse(rawStart.toString()) ?? 0;
+        start = Duration(milliseconds: ms);
+      }
+      lines.add(LyricsLine(start: start, text: value));
+    }
+    return Lyrics(
+      synced: synced,
+      lang: json['lang']?.toString(),
+      displayArtist: json['displayArtist']?.toString(),
+      displayTitle: json['displayTitle']?.toString(),
+      lines: lines,
+    );
+  }
+
+  /// Parse the legacy Subsonic `getLyrics` response (plain text only).
+  factory Lyrics.fromPlain(Map<String, dynamic> json) {
+    final text = (json['value'] ?? '').toString();
+    final lines = text
+        .split('\n')
+        .map((l) => LyricsLine(text: l))
+        .toList();
+    return Lyrics(
+      synced: false,
+      displayArtist: json['artist']?.toString(),
+      displayTitle: json['title']?.toString(),
+      lines: lines,
+    );
+  }
+}

--- a/lib/providers/cache_provider.dart
+++ b/lib/providers/cache_provider.dart
@@ -83,7 +83,6 @@ class CacheProvider extends ChangeNotifier {
     await Future.delayed(const Duration(seconds: 3));
 
     if (_libraryScanService != null) {
-      if (kDebugMode) print('[CacheProvider] Initiating background library scan');
       _libraryScanService!.startBackgroundScan();
     }
   }
@@ -117,8 +116,6 @@ class CacheProvider extends ChangeNotifier {
     // Suspend child services
     _libraryScanService?.stopPeriodicScanning();
     _aggressiveCacheService?.suspend();
-
-    if (kDebugMode) print('[CacheProvider] Suspended all background tasks');
   }
 
   /// Resume all background sync tasks
@@ -132,8 +129,6 @@ class CacheProvider extends ChangeNotifier {
     // Resume child services
     _libraryScanService?.resumePeriodicScanning();
     _aggressiveCacheService?.resume();
-
-    if (kDebugMode) print('[CacheProvider] Resumed all background tasks');
   }
   
   // Manual library scan (can be triggered by user)

--- a/lib/providers/network_provider.dart
+++ b/lib/providers/network_provider.dart
@@ -71,7 +71,6 @@ class NetworkProvider extends ChangeNotifier {
   }
   
   Future<void> _initialize() async {
-    debugPrint('[NetworkProvider] Initializing...');
 
     // Check if running in Flatpak or other container without D-Bus access
     _isFlatpak = Platform.isLinux &&
@@ -79,14 +78,11 @@ class NetworkProvider extends ChangeNotifier {
                    File('/.flatpak-info').existsSync() ||
                    Platform.environment['container'] != null || // Toolbx/Podman
                    !File('/var/run/dbus/system_bus_socket').existsSync());
-    debugPrint('[NetworkProvider] Running in container/no D-Bus: $_isFlatpak');
-
     // Check initial connectivity
     await _checkConnectivity();
 
     // Skip connectivity_plus stream in containers - it requires D-Bus
     if (_isFlatpak) {
-      debugPrint('[NetworkProvider] Container detected - skipping connectivity_plus stream');
       // Set up periodic internet check instead
       _startPeriodicConnectivityCheck();
       return;
@@ -123,7 +119,6 @@ class NetworkProvider extends ChangeNotifier {
   Future<void> _checkConnectivity() async {
     // In containers without D-Bus, skip connectivity_plus and check directly
     if (_isFlatpak) {
-      debugPrint('[NetworkProvider] Container detected - checking internet directly');
       final hasInternet = await _checkInternetAccess();
       if (hasInternet) {
         _handleConnectivityChange([ConnectivityResult.wifi]);
@@ -170,8 +165,7 @@ class NetworkProvider extends ChangeNotifier {
 
       // Any successful response means we have internet
       return response.statusCode >= 200 && response.statusCode < 300;
-    } catch (e) {
-      debugPrint('[NetworkProvider] Internet check failed: $e');
+    } catch (_) {
       return false;
     }
   }
@@ -208,14 +202,12 @@ class NetworkProvider extends ChangeNotifier {
   /// Suspend health check timer (for battery optimization when idle)
   void suspendHealthChecks() {
     _stopServerHealthMonitoring();
-    debugPrint('[NetworkProvider] Health checks suspended');
   }
 
   /// Resume health check timer
   void resumeHealthChecks() {
     if (_api != null && !_isOffline) {
       _startServerHealthMonitoring();
-      debugPrint('[NetworkProvider] Health checks resumed');
     }
   }
 
@@ -230,7 +222,6 @@ class NetworkProvider extends ChangeNotifier {
         _connectionState = ConnectionState.connected;
         _connectionEventController.add(ConnectionEvent.serverRestored);
         _consecutiveFailures = 0;
-        debugPrint('[NetworkProvider] Server restored');
         notifyListeners();
       } else if (!reachable && _serverReachable) {
         // Require 2 consecutive failures before marking unreachable
@@ -331,7 +322,6 @@ class NetworkProvider extends ChangeNotifier {
       _serverReachable = true;
       _connectionState = ConnectionState.connected;
       _connectionEventController.add(ConnectionEvent.reconnected);
-      debugPrint('[NetworkProvider] Network restored - back online');
       _startServerHealthMonitoring();
       notifyListeners();
     }
@@ -340,8 +330,6 @@ class NetworkProvider extends ChangeNotifier {
   void _handleConnectivityChange(List<ConnectivityResult> results) {
     NetworkType newType;
     bool offline = false;
-
-    debugPrint('[NetworkProvider] Handling connectivity change: $results');
 
     if (results.isEmpty || results.contains(ConnectivityResult.none)) {
       newType = NetworkType.offline;
@@ -364,8 +352,6 @@ class NetworkProvider extends ChangeNotifier {
       final wasOffline = _isOffline;
       _currentNetworkType = newType;
       _isOffline = offline;
-
-      debugPrint('[NetworkProvider] Network changed: $oldType -> $newType (offline: $wasOffline -> $offline)');
 
       // Emit connection events and trigger reconnection
       if (wasOffline && !offline) {

--- a/lib/providers/player_provider.dart
+++ b/lib/providers/player_provider.dart
@@ -80,7 +80,17 @@ class PlayerProvider extends ChangeNotifier {
   bool get isPlaying => _isPlaying;
   bool get isBuffering => _isBuffering;
   Duration get position => _position;
-  Duration get duration => _duration;
+  /// Effective duration: prefer mpv's reported duration once a file is loaded,
+  /// otherwise fall back to the current song's metadata so UI elements like
+  /// the progress slider have a meaningful range immediately on app open.
+  Duration get duration {
+    if (_duration > Duration.zero) return _duration;
+    final songDur = _currentSong?.duration;
+    if (songDur != null && songDur > 0) {
+      return Duration(seconds: songDur);
+    }
+    return Duration.zero;
+  }
   double get volume => _volume;
   String? get currentStreamUrl => _currentSong != null && _api != null
       ? _api!.getStreamUrl(_currentSong!.id, suffix: _currentSong!.suffix)
@@ -248,11 +258,6 @@ class PlayerProvider extends ChangeNotifier {
       // Clear error when playback starts successfully
       if (state.processingState == ProcessingState.ready && state.playing) {
         _lastError = null;
-      }
-
-      // Debug logging to see what states we're getting
-      if (kDebugMode) {
-        print('[PlayerProvider] PlayerState: playing=${state.playing}, processingState=${state.processingState}, isBuffering=$_isBuffering');
       }
 
       if (state.processingState == ProcessingState.completed) {
@@ -464,8 +469,7 @@ class PlayerProvider extends ChangeNotifier {
     
     if (_currentSong != null && _api != null && !_hasRestoredPosition) {
       _isRestoring = true;
-      if (kDebugMode) print('[PlayerProvider] API set, restoring audio for ${_currentSong!.title}');
-      
+
       // Store the position we want to restore
       final targetPosition = _position;
       
@@ -496,34 +500,32 @@ class PlayerProvider extends ChangeNotifier {
             _canPlayCurrentOffline = false;
           }
 
-          // Fall back to streaming if not cached
-          if (audioSource == null && !_networkProvider!.isOffline) {
-            audioSource = _api!.getStreamUrl(_currentSong!.id, transcode: false, suffix: _currentSong!.suffix);
+          // Fall back to streaming. Attempt the URL even if NetworkProvider
+          // currently reports offline — its detection is best-effort and
+          // sometimes false-positive at startup; mpv will surface a real
+          // load error if the URL is actually unreachable.
+          if (audioSource == null) {
+            audioSource = _api!.getStreamUrl(
+              _currentSong!.id,
+              transcode: false,
+              suffix: _currentSong!.suffix,
+            );
             _isPlayingOffline = false;
-          } else if (audioSource == null && _networkProvider!.isOffline) {
-            _isPlayingOffline = false;
-            _canPlayCurrentOffline = false;
-            if (kDebugMode) print('[PlayerProvider] ✗ Offline and no cached file for ${_currentSong!.title} - CANNOT PLAY');
-            return;
           }
 
           if (audioSource != null) {
             if (kDebugMode) print('[PlayerProvider] MpvPlayer restoring: $audioSource');
-            // Load paused (autoPlay: false)
-            await app_main.globalMpvPlayer!.load(audioSource, autoPlay: false);
-
-            // Seek to saved position
-            if (targetPosition.inMilliseconds > 0) {
-              if (kDebugMode) print('[PlayerProvider] Seeking to saved position: $targetPosition');
-              await app_main.globalMpvPlayer!.seek(targetPosition);
-              _position = targetPosition;
-            }
+            await app_main.globalMpvPlayer!.load(
+              audioSource,
+              autoPlay: false,
+              startPosition: targetPosition.inMilliseconds > 0 ? targetPosition : null,
+            );
+            _position = targetPosition;
           }
           _hasRestoredPosition = true;
         }
         // On Linux/Windows without MpvPlayer, we can't play - just mark as restored
         else if (Platform.isLinux || Platform.isWindows) {
-          if (kDebugMode) print('[PlayerProvider] ✗ MpvPlayer not available on ${Platform.operatingSystem} - cannot restore playback');
           _hasRestoredPosition = true;
           // Don't try to use just_audio on Linux/Windows - it won't work
         }
@@ -654,7 +656,28 @@ class PlayerProvider extends ChangeNotifier {
 
 
   Future<void> playQueue(List<Song> songs, {int startIndex = 0}) async {
-    if (_api == null || songs.isEmpty) return;
+    print('[PlayerProvider] playQueue: ${songs.length} songs, start=$startIndex, _useMpv=$_useMpv, mpvInitialized=${app_main.globalMpvPlayer?.isInitialized}');
+    if (_api == null || songs.isEmpty) {
+      print('[PlayerProvider] playQueue early-return: api=${_api != null}, songs=${songs.length}');
+      return;
+    }
+
+    // Lazy MpvPlayer init on Linux/Windows — covers the case where main()
+    // didn't run (hot reload) or initial init failed transiently.
+    if ((Platform.isLinux || Platform.isWindows) && !_useMpv) {
+      print('[PlayerProvider] MpvPlayer not ready — attempting lazy init...');
+      try {
+        app_main.globalMpvPlayer ??= MpvPlayer();
+        if (!app_main.globalMpvPlayer!.isInitialized) {
+          final ok = await app_main.globalMpvPlayer!.initialize();
+          print('[PlayerProvider] Lazy MpvPlayer init: ${ok ? "ready" : "failed"}');
+          if (!ok) app_main.globalMpvPlayer = null;
+        }
+      } catch (e, st) {
+        print('[PlayerProvider] Lazy MpvPlayer init threw: $e\n$st');
+        app_main.globalMpvPlayer = null;
+      }
+    }
 
     // Debounce rapid calls (e.g., from GTK input issues)
     final now = DateTime.now();
@@ -737,8 +760,12 @@ class PlayerProvider extends ChangeNotifier {
       }
 
       if (audioSource != null) {
-        if (kDebugMode) print('[PlayerProvider] MpvPlayer loading: $audioSource');
-        await app_main.globalMpvPlayer!.load(audioSource);
+        if (kDebugMode) print('[PlayerProvider] MpvPlayer loading: ${_currentSong!.title}');
+        try {
+          await app_main.globalMpvPlayer!.load(audioSource);
+        } catch (e, st) {
+          print('[PlayerProvider] MpvPlayer.load() failed: $e\n$st');
+        }
 
         // Show notification for track change on Linux
         if (Platform.isLinux) {
@@ -748,7 +775,7 @@ class PlayerProvider extends ChangeNotifier {
     }
     // On Linux/Windows without MpvPlayer, we can't play
     else if (Platform.isLinux || Platform.isWindows) {
-      if (kDebugMode) print('[PlayerProvider] ✗ MpvPlayer not available on ${Platform.operatingSystem} - cannot play');
+      print('[PlayerProvider] Cannot play — MpvPlayer is not initialized');
       return;
     }
     // Update audio handler for Android media session with current cached art
@@ -835,6 +862,7 @@ class PlayerProvider extends ChangeNotifier {
   }
 
   Future<void> play() async {
+    print('[PlayerProvider] play() called, _useMpv=$_useMpv, currentSong=${_currentSong?.title}');
     // Check if we can play offline
     if (_networkProvider?.isOffline == true && !_canPlayCurrentOffline) {
       if (kDebugMode) print('[PlayerProvider] Cannot play offline - no cached file');
@@ -842,10 +870,51 @@ class PlayerProvider extends ChangeNotifier {
     }
 
     if (_useMpv) {
-      await app_main.globalMpvPlayer!.play();
+      // If mpv has nothing loaded (e.g., state was restored while offline and
+      // we never got a chance to load the current song), load it now. Pass
+      // `_position` as startPosition so loadfile begins at the right offset
+      // — a post-load seek often arrives before the file is ready.
+      final mpv = app_main.globalMpvPlayer!;
+      if (mpv.state == MpvPlayerState.idle && _currentSong != null && _api != null) {
+        final audioSource = await _resolveCurrentAudioSource();
+        if (audioSource != null) {
+          await mpv.load(
+            audioSource,
+            autoPlay: true,
+            startPosition: _position.inMilliseconds > 0 ? _position : null,
+          );
+          if (Platform.isLinux) _showTrackNotification(_currentSong!);
+          return;
+        }
+      }
+      await mpv.play();
     } else {
       await _audioPlayer.play();
     }
+  }
+
+  /// Resolve the best audio source for the current song (cached file if
+  /// available, else a stream URL). Returns null if neither is reachable.
+  Future<String?> _resolveCurrentAudioSource() async {
+    if (_currentSong == null) return null;
+    final cachedPath = await _getCachedAudioPath(_currentSong!.id);
+    if (cachedPath != null) {
+      final cachedFile = File(cachedPath);
+      if (await cachedFile.exists() && await cachedFile.length() > 1000) {
+        _isPlayingOffline = true;
+        _canPlayCurrentOffline = true;
+        return cachedPath;
+      }
+    }
+    if (_api != null && !(_networkProvider?.isOffline ?? false)) {
+      _isPlayingOffline = false;
+      return _api!.getStreamUrl(
+        _currentSong!.id,
+        transcode: false,
+        suffix: _currentSong!.suffix,
+      );
+    }
+    return null;
   }
 
   Future<void> pause() async {
@@ -1202,8 +1271,6 @@ class PlayerProvider extends ChangeNotifier {
     final positionMillis = prefs.getInt('player_position') ?? 0;
     final volume = prefs.getDouble('player_volume') ?? 1.0;
     
-    if (kDebugMode) print('[PlayerProvider] Loading persisted state - position: ${positionMillis}ms');
-    
     if (currentSongJson != null && queueJson != null) {
       try {
         final songMap = json.decode(currentSongJson);
@@ -1239,12 +1306,9 @@ class PlayerProvider extends ChangeNotifier {
         _currentIndex = currentIndex;
         _position = Duration(milliseconds: positionMillis);
         _volume = volume;
-        
+
         await _audioPlayer.setVolume(_volume);
-        
-        // Just restore the state, don't load audio yet (API might not be set)
-        if (kDebugMode) print('[PlayerProvider] State restored, waiting for API to load audio');
-        
+
         notifyListeners();
         
         // Try to restore audio if API is already available
@@ -1632,15 +1696,8 @@ class PlayerProvider extends ChangeNotifier {
 
   /// Called when network reconnects - attempt to recover playback if needed
   Future<void> _onNetworkReconnected() async {
-    if (kDebugMode) {
-      print('[PlayerProvider] Network reconnected, checking if recovery needed');
-    }
-
     // If we're buffering and have a current song, try to recover
     if (_isBuffering && _currentSong != null && !_isRecovering) {
-      if (kDebugMode) {
-        print('[PlayerProvider] Was buffering, attempting recovery');
-      }
       await _recoverPlayback();
     }
   }
@@ -1683,11 +1740,6 @@ class PlayerProvider extends ChangeNotifier {
     final savedPosition = _position;
     final wasPlaying = _isPlaying;
 
-    if (kDebugMode) {
-      print(
-          '[PlayerProvider] Recovering playback for ${_currentSong!.title} at $savedPosition');
-    }
-
     // Use MpvPlayer on Linux/Windows
     if (_useMpv) {
       // Try cached file first
@@ -1714,9 +1766,6 @@ class PlayerProvider extends ChangeNotifier {
           if (savedPosition.inMilliseconds > 0) {
             await app_main.globalMpvPlayer!.seek(savedPosition);
           }
-          if (kDebugMode) {
-            print('[PlayerProvider] Recovery: Using MpvPlayer');
-          }
           notifyListeners();
           return;
         } catch (e) {
@@ -1725,18 +1774,11 @@ class PlayerProvider extends ChangeNotifier {
           }
         }
       }
-
-      if (kDebugMode) {
-        print('[PlayerProvider] Recovery failed, no options left');
-      }
       return;
     }
 
     // On Linux/Windows without MpvPlayer, we can't recover
     if (Platform.isLinux || Platform.isWindows) {
-      if (kDebugMode) {
-        print('[PlayerProvider] Recovery failed - MpvPlayer not available');
-      }
       return;
     }
 

--- a/lib/providers/player_provider.dart
+++ b/lib/providers/player_provider.dart
@@ -888,6 +888,8 @@ class PlayerProvider extends ChangeNotifier {
         }
       }
       await mpv.play();
+    } else if (Platform.isAndroid && app_main.audioHandler != null) {
+      await app_main.audioHandler!.play();
     } else {
       await _audioPlayer.play();
     }
@@ -920,6 +922,8 @@ class PlayerProvider extends ChangeNotifier {
   Future<void> pause() async {
     if (_useMpv) {
       await app_main.globalMpvPlayer!.pause();
+    } else if (Platform.isAndroid && app_main.audioHandler != null) {
+      await app_main.audioHandler!.pause();
     } else {
       await _audioPlayer.pause();
     }
@@ -1237,6 +1241,10 @@ class PlayerProvider extends ChangeNotifier {
   Future<void> seek(Duration position) async {
     if (_useMpv) {
       await app_main.globalMpvPlayer!.seek(position);
+    } else if (Platform.isAndroid && app_main.audioHandler != null) {
+      // Route through audio_service so the media session, notification and
+      // lockscreen scrubber all stay in sync with the player.
+      await app_main.audioHandler!.seek(position);
     } else {
       await _audioPlayer.seek(position);
     }

--- a/lib/screens/album_detail_screen.dart
+++ b/lib/screens/album_detail_screen.dart
@@ -84,9 +84,6 @@ class _AlbumDetailScreenState extends State<AlbumDetailScreen> {
   }
 
   Future<void> _loadAlbumDetails() async {
-    if (kDebugMode) {
-      print('[AlbumDetailScreen] Loading album details for: ${widget.album.name}');
-    }
     final cacheProvider = context.read<CacheProvider>();
     final networkProvider = context.read<NetworkProvider>();
     final albumDownloadService = context.read<AlbumDownloadService?>();
@@ -99,27 +96,15 @@ class _AlbumDetailScreenState extends State<AlbumDetailScreen> {
     try {
       // Always try cache first, never force refresh by default
       final forceRefresh = false;
-      if (kDebugMode) {
-        print('[AlbumDetailScreen] Fetching songs from cache... (forceRefresh: $forceRefresh)');
-      }
       final songs = await cacheProvider.getSongsByAlbum(
         widget.album.id,
         forceRefresh: forceRefresh,
       );
-      if (kDebugMode) {
-        print('[AlbumDetailScreen] Found ${songs.length} songs');
-      }
 
       // Check for existing album download progress
       final albumDownloadProgress = albumDownloadService != null
           ? await albumDownloadService.getAlbumDownload(widget.album.id)
           : null;
-
-      if (kDebugMode) {
-        if (albumDownloadProgress != null) {
-          print('[AlbumDetailScreen] Found existing download progress: ${albumDownloadProgress.status} (${albumDownloadProgress.progress}%)');
-        }
-      }
 
       if (mounted) {
         setState(() {
@@ -127,9 +112,6 @@ class _AlbumDetailScreenState extends State<AlbumDetailScreen> {
           _isLoading = false;
           _albumDownloadProgress = albumDownloadProgress;
         });
-        if (kDebugMode) {
-          print('[AlbumDetailScreen] UI updated successfully');
-        }
 
         // If no songs found and we're online, trigger a scan to pick up new tracks
         if (songs.isEmpty && !networkProvider.isOffline && networkProvider.isServerReachable) {

--- a/lib/screens/home_view.dart
+++ b/lib/screens/home_view.dart
@@ -90,8 +90,6 @@ class _HomeViewState extends State<HomeView> {
     final cacheProvider = context.read<CacheProvider>();
     final networkProvider = context.read<NetworkProvider>();
 
-    debugPrint('[HomeView] _loadData called - api: ${api != null}, forceRefresh: $forceRefresh, showLoading: $showLoading');
-
     // Only show loading spinner on first load (when no data exists)
     if (showLoading && _recentlyAdded == null) {
       setState(() {
@@ -107,26 +105,21 @@ class _HomeViewState extends State<HomeView> {
 
       // Always load cached album IDs for opacity
       final cachedAlbumIds = await DatabaseHelper.getCachedAlbumIds();
-      debugPrint('[HomeView] Cached album IDs: ${cachedAlbumIds.length}');
 
       // Always load popular offline albums (for when we switch to offline mode)
       popularOffline = await DatabaseHelper.getPopularOfflineAlbums();
-      debugPrint('[HomeView] Popular offline albums: ${popularOffline.length}');
 
       // ALWAYS try cache first - this ensures we show something immediately
       try {
         recentlyAdded = await cacheProvider.getRecentlyAdded(forceRefresh: false);
-        debugPrint('[HomeView] Recently added from cache: ${recentlyAdded.length}');
       } catch (e) {
         debugPrint('[HomeView] Error loading recently added: $e');
       }
 
       // If cache is empty, try getting all albums
       if (recentlyAdded.isEmpty) {
-        debugPrint('[HomeView] Cache empty, trying all albums...');
         try {
           final allAlbums = await cacheProvider.getAlbums(forceRefresh: false);
-          debugPrint('[HomeView] All albums from cache: ${allAlbums.length}');
           allAlbums.sort((a, b) => b.id.compareTo(a.id));
           recentlyAdded = allAlbums.take(18).toList();
         } catch (e) {
@@ -135,7 +128,6 @@ class _HomeViewState extends State<HomeView> {
       }
 
       // Update UI with cached data immediately
-      debugPrint('[HomeView] Setting state with ${recentlyAdded.length} albums, mounted: $mounted');
       if (mounted && recentlyAdded.isNotEmpty) {
         setState(() {
           _recentlyAdded = recentlyAdded;

--- a/lib/screens/lyrics_screen.dart
+++ b/lib/screens/lyrics_screen.dart
@@ -1,0 +1,267 @@
+import 'dart:io';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:provider/provider.dart';
+import '../models/lyrics.dart';
+import '../models/song.dart';
+import '../providers/auth_provider.dart';
+import '../providers/player_provider.dart';
+import '../widgets/custom_window_frame.dart';
+
+class LyricsScreen extends StatefulWidget {
+  final Song song;
+
+  const LyricsScreen({super.key, required this.song});
+
+  @override
+  State<LyricsScreen> createState() => _LyricsScreenState();
+}
+
+class _LyricsScreenState extends State<LyricsScreen> {
+  Lyrics? _lyrics;
+  bool _loading = true;
+  String? _error;
+
+  final ScrollController _scrollController = ScrollController();
+  final Map<int, GlobalKey> _lineKeys = {};
+  int _activeLineIndex = -1;
+  String? _loadedSongId;
+
+  @override
+  void initState() {
+    super.initState();
+    _fetchLyrics(widget.song);
+  }
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _fetchLyrics(Song song) async {
+    _loadedSongId = song.id;
+    setState(() {
+      _loading = true;
+      _error = null;
+      _lyrics = null;
+      _activeLineIndex = -1;
+      _lineKeys.clear();
+    });
+
+    final api = context.read<AuthProvider>().api;
+    if (api == null) {
+      if (!mounted) return;
+      setState(() {
+        _loading = false;
+        _error = 'Not connected';
+      });
+      return;
+    }
+
+    try {
+      final lyrics = await api.getLyricsBySongId(
+        song.id,
+        artist: song.artist,
+        title: song.title,
+      );
+      if (!mounted || _loadedSongId != song.id) return;
+      setState(() {
+        _lyrics = lyrics;
+        _loading = false;
+      });
+    } catch (e) {
+      if (!mounted || _loadedSongId != song.id) return;
+      setState(() {
+        _loading = false;
+        _error = 'Could not load lyrics';
+      });
+    }
+  }
+
+  int _findActiveLine(Duration position) {
+    final lyrics = _lyrics;
+    if (lyrics == null || !lyrics.synced) return -1;
+    int idx = -1;
+    for (var i = 0; i < lyrics.lines.length; i++) {
+      final start = lyrics.lines[i].start;
+      if (start == null) continue;
+      if (start <= position) {
+        idx = i;
+      } else {
+        break;
+      }
+    }
+    return idx;
+  }
+
+  void _scrollToActive(int index) {
+    if (index < 0) return;
+    final key = _lineKeys[index];
+    final ctx = key?.currentContext;
+    if (ctx == null) return;
+    Scrollable.ensureVisible(
+      ctx,
+      duration: const Duration(milliseconds: 350),
+      curve: Curves.easeOutCubic,
+      alignment: 0.4,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final scaffold = Consumer<PlayerProvider>(
+      builder: (context, player, _) {
+        final currentSong = player.currentSong;
+
+        // If track changed, reload lyrics for the new song.
+        if (currentSong != null && currentSong.id != _loadedSongId) {
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            if (mounted) _fetchLyrics(currentSong);
+          });
+        }
+
+        final lyrics = _lyrics;
+        if (lyrics != null && lyrics.synced) {
+          final newIndex = _findActiveLine(player.position);
+          if (newIndex != _activeLineIndex) {
+            _activeLineIndex = newIndex;
+            WidgetsBinding.instance.addPostFrameCallback((_) {
+              _scrollToActive(newIndex);
+            });
+          }
+        }
+
+        return Scaffold(
+          appBar: AppBar(
+            backgroundColor: Colors.transparent,
+            elevation: 0,
+            leading: IconButton(
+              icon: const Icon(Icons.arrow_back),
+              onPressed: () => Navigator.of(context).pop(),
+            ),
+            title: Text(
+              currentSong?.title ?? widget.song.title,
+              style: Theme.of(context).textTheme.titleMedium,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+          body: SafeArea(child: _buildBody(player)),
+        );
+      },
+    );
+
+    if (Platform.isWindows || Platform.isLinux || Platform.isMacOS) {
+      return RawKeyboardListener(
+        focusNode: FocusNode(),
+        autofocus: true,
+        onKey: (event) {
+          if (event is RawKeyDownEvent &&
+              event.logicalKey == LogicalKeyboardKey.escape) {
+            Navigator.of(context).pop();
+          }
+        },
+        child: CustomWindowFrame(child: scaffold),
+      );
+    }
+    return scaffold;
+  }
+
+  Widget _buildBody(PlayerProvider player) {
+    if (_loading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+    if (_error != null) {
+      return Center(
+        child: Text(
+          _error!,
+          style: Theme.of(context).textTheme.bodyLarge,
+        ),
+      );
+    }
+    final lyrics = _lyrics;
+    if (lyrics == null || lyrics.isEmpty) {
+      return Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(
+              Icons.lyrics_outlined,
+              size: 56,
+              color: Theme.of(context).colorScheme.onSurface.withOpacity(0.4),
+            ),
+            const SizedBox(height: 12),
+            Text(
+              'No lyrics available',
+              style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                    color: Theme.of(context).colorScheme.onSurface.withOpacity(0.6),
+                  ),
+            ),
+          ],
+        ),
+      );
+    }
+
+    final theme = Theme.of(context);
+    final inactiveColor = theme.colorScheme.onSurface.withOpacity(0.65);
+    // Active uses full-opacity onSurface (pure white in dark mode) for maximum
+    // brightness; size+weight bump keeps the visual emphasis for CJK glyphs.
+    final activeColor = theme.colorScheme.onSurface;
+
+    final baseStyle = TextStyle(
+      fontSize: 26,
+      height: 1.4,
+      fontWeight: FontWeight.w600,
+      color: inactiveColor,
+    );
+    final activeStyle = TextStyle(
+      fontSize: 32,
+      height: 1.4,
+      fontWeight: FontWeight.w800,
+      color: activeColor,
+    );
+
+    return ListView.builder(
+      controller: _scrollController,
+      padding: EdgeInsets.symmetric(
+        horizontal: 24,
+        vertical: MediaQuery.of(context).size.height * 0.3,
+      ),
+      itemCount: lyrics.lines.length,
+      itemBuilder: (context, index) {
+        final line = lyrics.lines[index];
+        final key = _lineKeys.putIfAbsent(index, () => GlobalKey());
+        final isActive = lyrics.synced && index == _activeLineIndex;
+        final text = line.text.trim();
+
+        Widget content = Padding(
+          key: key,
+          padding: const EdgeInsets.symmetric(vertical: 12),
+          child: AnimatedDefaultTextStyle(
+            duration: const Duration(milliseconds: 250),
+            curve: Curves.easeOut,
+            style: isActive ? activeStyle : baseStyle,
+            child: Text(
+              text.isEmpty ? '\u00B7' : text,
+              textAlign: TextAlign.center,
+            ),
+          ),
+        );
+
+        if (lyrics.synced && line.start != null) {
+          content = InkWell(
+            borderRadius: BorderRadius.circular(8),
+            onTap: () async {
+              await player.seek(line.start!);
+              if (!player.isPlaying) {
+                await player.play();
+              }
+            },
+            child: content,
+          );
+        }
+        return content;
+      },
+    );
+  }
+}

--- a/lib/screens/lyrics_screen.dart
+++ b/lib/screens/lyrics_screen.dart
@@ -252,10 +252,13 @@ class _LyricsScreenState extends State<LyricsScreen> {
           content = InkWell(
             borderRadius: BorderRadius.circular(8),
             onTap: () async {
-              await player.seek(line.start!);
+              // Start playback first if paused, then seek. just_audio on
+              // Android discards a seek issued while the source is idle —
+              // play() re-prepares from 0 and the seek would be lost.
               if (!player.isPlaying) {
                 await player.play();
               }
+              await player.seek(line.start!);
             },
             child: content,
           );

--- a/lib/screens/now_playing_screen.dart
+++ b/lib/screens/now_playing_screen.dart
@@ -9,13 +9,21 @@ import '../providers/player_provider.dart';
 import '../providers/auth_provider.dart';
 import '../models/artist.dart';
 import '../models/album.dart';
+import '../models/song.dart';
 import '../services/share_service.dart';
 import '../widgets/cached_cover_image.dart';
 import 'artist_detail_screen.dart';
 import 'album_detail_screen.dart';
+import 'lyrics_screen.dart';
 
 class NowPlayingScreen extends StatelessWidget {
   const NowPlayingScreen({super.key});
+
+  void _openLyrics(BuildContext context, Song song) {
+    Navigator.of(context).push(
+      MaterialPageRoute(builder: (_) => LyricsScreen(song: song)),
+    );
+  }
 
   // Calculate appropriate icon color based on HSL values
   Color _getContrastIconColor(Color backgroundColor) {
@@ -97,7 +105,9 @@ class NowPlayingScreen extends StatelessWidget {
                   child: (Platform.isWindows || Platform.isLinux || Platform.isMacOS)
                       ? DragToMoveArea(
                           child: Center(
-                            child: Container(
+                            child: GestureDetector(
+                              onTap: () => _openLyrics(context, song),
+                              child: Container(
                               constraints: const BoxConstraints(maxWidth: 360, maxHeight: 360),
                               decoration: BoxDecoration(
                                 borderRadius: BorderRadius.circular(20),
@@ -163,10 +173,13 @@ class NowPlayingScreen extends StatelessWidget {
                                 ),
                               ),
                             ),
+                            ),
                           ),
                         )
                       : Center(
-                          child: Container(
+                          child: GestureDetector(
+                            onTap: () => _openLyrics(context, song),
+                            child: Container(
                             constraints: const BoxConstraints(maxWidth: 360, maxHeight: 360),
                             decoration: BoxDecoration(
                               borderRadius: BorderRadius.circular(20),
@@ -230,6 +243,7 @@ class NowPlayingScreen extends StatelessWidget {
                                   ),
                                 ),
                               ),
+                            ),
                             ),
                           ),
                         ),

--- a/lib/services/activity_coordinator.dart
+++ b/lib/services/activity_coordinator.dart
@@ -58,10 +58,6 @@ class ActivityCoordinator extends ChangeNotifier {
     _isInForeground = isForeground;
     final nowIdle = isIdle;
 
-    if (kDebugMode) {
-      debugPrint('[ActivityCoordinator] Foreground: $isForeground, isIdle: $nowIdle');
-    }
-
     _notifyStateChange(wasIdle, nowIdle);
     notifyListeners();
   }
@@ -73,10 +69,6 @@ class ActivityCoordinator extends ChangeNotifier {
     final wasIdle = this.isIdle;
     _isPlaying = isPlaying;
     final nowIdle = this.isIdle;
-
-    if (kDebugMode) {
-      debugPrint('[ActivityCoordinator] Playing: $isPlaying, isIdle: $nowIdle');
-    }
 
     _notifyStateChange(wasIdle, nowIdle);
     notifyListeners();
@@ -90,10 +82,6 @@ class ActivityCoordinator extends ChangeNotifier {
     _isDownloading = isDownloading;
     final nowIdle = this.isIdle;
 
-    if (kDebugMode) {
-      debugPrint('[ActivityCoordinator] Downloading: $isDownloading, isIdle: $nowIdle');
-    }
-
     _notifyStateChange(wasIdle, nowIdle);
     notifyListeners();
   }
@@ -101,17 +89,11 @@ class ActivityCoordinator extends ChangeNotifier {
   void _notifyStateChange(bool wasIdle, bool nowIdle) {
     if (!wasIdle && nowIdle) {
       // Transitioning to idle - suspend all background tasks
-      if (kDebugMode) {
-        debugPrint('[ActivityCoordinator] Suspending background tasks');
-      }
       for (final callback in _suspendCallbacks) {
         callback();
       }
     } else if (wasIdle && !nowIdle) {
       // Transitioning from idle - resume background tasks
-      if (kDebugMode) {
-        debugPrint('[ActivityCoordinator] Resuming background tasks');
-      }
       for (final callback in _resumeCallbacks) {
         callback();
       }

--- a/lib/services/aggressive_cache_service.dart
+++ b/lib/services/aggressive_cache_service.dart
@@ -67,14 +67,12 @@ class AggressiveCacheService {
     _isSuspended = true;
     _syncTimer?.cancel();
     _syncTimer = null;
-    if (kDebugMode) debugPrint('[AggressiveCache] Suspended - timers stopped');
   }
 
   /// Resume background sync tasks
   void resume() {
     _isSuspended = false;
     _startPeriodicSync();
-    if (kDebugMode) debugPrint('[AggressiveCache] Resumed - timers restarted');
   }
 
   Future<void> smartSync() async {

--- a/lib/services/audio_cache_manager.dart
+++ b/lib/services/audio_cache_manager.dart
@@ -50,14 +50,12 @@ class AudioCacheManager {
     _isSuspended = true;
     _cleanupTimer?.cancel();
     _cleanupTimer = null;
-    print('[AudioCache] Suspended - cleanup timer stopped');
   }
 
   /// Resume cleanup timer
   void resume() {
     _isSuspended = false;
     initialize();
-    print('[AudioCache] Resumed - cleanup timer restarted');
   }
   
   Future<AudioPlayer?> preloadTrack(String songId, String streamUrl) async {

--- a/lib/services/library_scan_service.dart
+++ b/lib/services/library_scan_service.dart
@@ -50,10 +50,6 @@ class LibraryScanService {
     // Use custom interval or default
     final interval = customInterval ?? _normalScanInterval;
     
-    if (kDebugMode) {
-      print('[LibraryScan] Starting periodic scanning every ${interval.inMinutes} minutes');
-    }
-    
     _periodicScanTimer = Timer.periodic(interval, (_) {
       _performPeriodicScan();
     });
@@ -65,13 +61,11 @@ class LibraryScanService {
     _periodicScanTimer = null;
     _statusCheckTimer?.cancel();
     _statusCheckTimer = null;
-    if (kDebugMode) print('[LibraryScan] Stopped periodic scanning');
   }
 
   // Resume periodic scanning (for battery optimization)
   void resumePeriodicScanning() {
     _startPeriodicScanning();
-    if (kDebugMode) print('[LibraryScan] Resumed periodic scanning');
   }
   
   // Adjust scan interval based on network conditions
@@ -110,7 +104,6 @@ class LibraryScanService {
       return;
     }
 
-    if (kDebugMode) print('[LibraryScan] Starting periodic scan');
     await startBackgroundScan();
   }
   
@@ -135,7 +128,6 @@ class LibraryScanService {
       await _captureLibraryState();
       
       // Start the scan
-      if (kDebugMode) print('[LibraryScan] Starting library scan...');
       await api.startScan();
       
       // Start monitoring scan status
@@ -164,9 +156,6 @@ class LibraryScanService {
         _lastAlbumIds = albums.take(100).map((a) => a.id).toList();
       }
       
-      if (kDebugMode) {
-        print('[LibraryScan] Captured state: $_lastAlbumCount albums, newest: $_lastNewestAlbumId');
-      }
     } catch (e) {
       if (kDebugMode) print('[LibraryScan] Error capturing library state: $e');
     }
@@ -181,13 +170,8 @@ class LibraryScanService {
         final status = await api.getScanStatus();
         final isScanning = status['scanning'] as bool? ?? false;
         
-        if (kDebugMode) {
-          print('[LibraryScan] Status: scanning=$isScanning, count=${status['count']}');
-        }
-        
         if (!isScanning && _isScanning) {
           // Scan just completed
-          if (kDebugMode) print('[LibraryScan] Scan completed, checking for changes...');
           _isScanning = false;
           _statusCheckTimer?.cancel();
           
@@ -219,36 +203,41 @@ class LibraryScanService {
         return;
       }
       
-      // Check if the newest album has changed
+      // Count new albums by walking the list until we hit the previously-known
+      // newest. If we don't find it (album removed/reordered, or no prior state),
+      // we can't infer "N new albums" — bail out instead of falsely reporting all 50.
       final currentNewestId = newestAlbums.first.id;
-      bool hasNewAlbums = _lastNewestAlbumId != null && _lastNewestAlbumId != currentNewestId;
-      
-      // Count new albums since last check
       int newAlbumCount = 0;
-      if (hasNewAlbums && _lastNewestAlbumId != null) {
+      bool hasNewAlbums = false;
+      if (_lastNewestAlbumId != null && _lastNewestAlbumId != currentNewestId) {
         for (final album in newestAlbums) {
-          if (album.id == _lastNewestAlbumId) break;
+          if (album.id == _lastNewestAlbumId) {
+            hasNewAlbums = true;
+            break;
+          }
           newAlbumCount++;
         }
+        if (!hasNewAlbums) {
+          // Stale reference — don't treat the entire window as new.
+          newAlbumCount = 0;
+        }
       }
-      
-      // Check total album count change
+
+      // Check total album count change. getAlbumList2 caps at 500 per page, so
+      // a library larger than 500 will produce a misleading negative diff. Only
+      // trust the diff when both sides were below the cap.
       final allAlbums = await api.getAlbumList2(
-        type: 'alphabeticalByName', 
-        size: 500
+        type: 'alphabeticalByName',
+        size: 500,
       );
       final currentAlbumCount = allAlbums.length;
-      final albumCountDiff = (_lastAlbumCount != null) 
-        ? currentAlbumCount - _lastAlbumCount! 
-        : 0;
-      
-      if (kDebugMode) {
-        print('[LibraryScan] Changes detected:');
-        print('  - New albums: $newAlbumCount');
-        print('  - Total album count change: $albumCountDiff');
-        print('  - Newest album changed: $hasNewAlbums');
-      }
-      
+      final bothBelowCap = currentAlbumCount < 500 &&
+          _lastAlbumCount != null &&
+          _lastAlbumCount! < 500;
+      final albumCountDiff = bothBelowCap
+          ? currentAlbumCount - _lastAlbumCount!
+          : 0;
+
       // Update cached albums in database
       if (hasNewAlbums || albumCountDiff > 0) {
         // Update database with new albums
@@ -275,11 +264,6 @@ class LibraryScanService {
           newestAlbums: newestAlbums.take(10).toList(),
         ));
         
-        if (kDebugMode) {
-          print('[LibraryScan] Library changes notified to listeners');
-        }
-      } else {
-        if (kDebugMode) print('[LibraryScan] No changes detected in library');
       }
       
       // Update state for next comparison

--- a/lib/services/navidrome_api.dart
+++ b/lib/services/navidrome_api.dart
@@ -7,6 +7,7 @@ import 'package:http/http.dart' as http;
 import '../models/artist.dart';
 import '../models/album.dart';
 import '../models/song.dart';
+import '../models/lyrics.dart';
 import '../providers/network_provider.dart';
 import 'auth_service.dart' show LoginResult;
 
@@ -375,6 +376,57 @@ class NavidromeApi {
 
   Future<void> unstar(String id) async {
     await _request('unstar', {'id': id});
+  }
+
+  /// Fetch lyrics for a song via OpenSubsonic's `getLyricsBySongId`,
+  /// which returns structured/synced lyrics when available. Falls back to
+  /// legacy `getLyrics(artist, title)` for plain text. Returns null if none.
+  Future<Lyrics?> getLyricsBySongId(
+    String id, {
+    String? artist,
+    String? title,
+  }) async {
+    try {
+      final response = await _request('getLyricsBySongId', {'id': id});
+      final list = response['lyricsList'];
+      if (list is Map && list['structuredLyrics'] is List) {
+        final entries = list['structuredLyrics'] as List;
+        if (entries.isNotEmpty) {
+          Map<String, dynamic>? chosen;
+          for (final e in entries) {
+            if (e is Map && e['synced'] == true) {
+              chosen = Map<String, dynamic>.from(e);
+              break;
+            }
+          }
+          chosen ??= Map<String, dynamic>.from(entries.first as Map);
+          final lyrics = Lyrics.fromStructured(chosen);
+          if (!lyrics.isEmpty) return lyrics;
+        }
+      }
+    } catch (e) {
+      if (kDebugMode) {
+        print('[NavidromeApi] getLyricsBySongId failed, falling back: $e');
+      }
+    }
+
+    if (artist == null || title == null) return null;
+    try {
+      final response = await _request('getLyrics', {
+        'artist': artist,
+        'title': title,
+      });
+      final raw = response['lyrics'];
+      if (raw is Map) {
+        final lyrics = Lyrics.fromPlain(Map<String, dynamic>.from(raw));
+        if (!lyrics.isEmpty) return lyrics;
+      }
+    } catch (e) {
+      if (kDebugMode) {
+        print('[NavidromeApi] getLyrics fallback failed: $e');
+      }
+    }
+    return null;
   }
 
   // Library scanning methods (Subsonic API v1.15.0+)

--- a/lib/services/performance_config.dart
+++ b/lib/services/performance_config.dart
@@ -18,13 +18,6 @@ class PerformanceConfig {
 
   /// Initialize configuration from environment variables
   static void initialize() {
-    if (kDebugMode) {
-      print('[PerformanceConfig] Initializing with defaults:');
-      print('  - enableGaplessPlayback: $enableGaplessPlayback');
-      print('  - positionUpdateInterval: $positionUpdateInterval ms');
-      print('  - enableAggressiveCaching: $enableAggressiveCaching');
-    }
-
     // Allow overriding with environment variables (useful for debugging)
     if (const String.fromEnvironment('ENABLE_GAPLESS') == 'true') {
       enableGaplessPlayback = true;

--- a/lib/widgets/custom_window_frame.dart
+++ b/lib/widgets/custom_window_frame.dart
@@ -69,6 +69,10 @@ class _CustomWindowFrameState extends State<CustomWindowFrame> {
       children: [
         // Main content
         widget.child,
+        // Resize handles around the window edges. TitleBarStyle.hidden tells
+        // GTK to drop its decorations, including the resize border, so we
+        // recreate them ourselves with windowManager.startResizing.
+        ..._resizeHandles(),
         // Hover area for window controls - positioned to match AppBar
         Positioned(
           top: 0,
@@ -112,6 +116,51 @@ class _CustomWindowFrameState extends State<CustomWindowFrame> {
         ),
       ],
     );
+  }
+
+  List<Widget> _resizeHandles() {
+    const thickness = 6.0;
+    const cornerSize = 12.0;
+
+    Widget edge({
+      required ResizeEdge edge,
+      double? top,
+      double? left,
+      double? right,
+      double? bottom,
+      double? width,
+      double? height,
+      MouseCursor? cursor,
+    }) {
+      return Positioned(
+        top: top,
+        left: left,
+        right: right,
+        bottom: bottom,
+        width: width,
+        height: height,
+        child: MouseRegion(
+          cursor: cursor ?? MouseCursor.defer,
+          child: GestureDetector(
+            behavior: HitTestBehavior.translucent,
+            onPanStart: (_) => windowManager.startResizing(edge),
+          ),
+        ),
+      );
+    }
+
+    return [
+      // Edges
+      edge(edge: ResizeEdge.top, top: 0, left: cornerSize, right: cornerSize, height: thickness, cursor: SystemMouseCursors.resizeUpDown),
+      edge(edge: ResizeEdge.bottom, bottom: 0, left: cornerSize, right: cornerSize, height: thickness, cursor: SystemMouseCursors.resizeUpDown),
+      edge(edge: ResizeEdge.left, left: 0, top: cornerSize, bottom: cornerSize, width: thickness, cursor: SystemMouseCursors.resizeLeftRight),
+      edge(edge: ResizeEdge.right, right: 0, top: cornerSize, bottom: cornerSize, width: thickness, cursor: SystemMouseCursors.resizeLeftRight),
+      // Corners
+      edge(edge: ResizeEdge.topLeft, top: 0, left: 0, width: cornerSize, height: cornerSize, cursor: SystemMouseCursors.resizeUpLeftDownRight),
+      edge(edge: ResizeEdge.topRight, top: 0, right: 0, width: cornerSize, height: cornerSize, cursor: SystemMouseCursors.resizeUpRightDownLeft),
+      edge(edge: ResizeEdge.bottomLeft, bottom: 0, left: 0, width: cornerSize, height: cornerSize, cursor: SystemMouseCursors.resizeUpRightDownLeft),
+      edge(edge: ResizeEdge.bottomRight, bottom: 0, right: 0, width: cornerSize, height: cornerSize, cursor: SystemMouseCursors.resizeUpLeftDownRight),
+    ];
   }
 }
 

--- a/lib/widgets/offline_indicator.dart
+++ b/lib/widgets/offline_indicator.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/foundation.dart';
 import 'package:provider/provider.dart';
 import '../providers/network_provider.dart';
 
@@ -10,11 +9,6 @@ class OfflineIndicator extends StatelessWidget {
   Widget build(BuildContext context) {
     return Consumer<NetworkProvider>(
       builder: (context, networkProvider, child) {
-        // Debug logging
-        if (kDebugMode) {
-          print('[OfflineIndicator] Building - isOffline: ${networkProvider.isOffline}');
-        }
-
         if (!networkProvider.isOffline) {
           return const SizedBox.shrink();
         }

--- a/linux/dev.myyc.nhac.metainfo.xml
+++ b/linux/dev.myyc.nhac.metainfo.xml
@@ -62,6 +62,20 @@
   </provides>
   
   <releases>
+    <release version="1.2.0" date="2026-04-14">
+      <description>
+        <p>Feature release</p>
+        <ul>
+          <li>Synced lyrics view (tap album cover in the player)</li>
+          <li>Linux: window resize handles for the custom title bar</li>
+          <li>Link libmpv at build time (pkg-config) instead of runtime dlopen</li>
+          <li>Fix play/pause button getting out of sync after a track loads</li>
+          <li>Fix library scan reporting phantom new albums</li>
+          <li>Reduce log noise</li>
+          <li>Bump pipewire 1.6.2 → 1.6.3</li>
+        </ul>
+      </description>
+    </release>
     <release version="1.0.0" date="2025-09-03">
       <description>
         <p>Initial release - A simple cross-platform Navidrome client</p>

--- a/linux/runner/CMakeLists.txt
+++ b/linux/runner/CMakeLists.txt
@@ -23,4 +23,11 @@ add_definitions(-DAPPLICATION_ID="${APPLICATION_ID}")
 target_link_libraries(${BINARY_NAME} PRIVATE flutter)
 target_link_libraries(${BINARY_NAME} PRIVATE PkgConfig::GTK)
 
+# Link libmpv at build time so the dynamic linker resolves it on app launch
+# (no runtime dlopen needed). Dart FFI then locates symbols via
+# DynamicLibrary.process(). Requires `mpv-libs-devel` (Fedora) or
+# `libmpv-dev` (Debian/Ubuntu) on the build host.
+pkg_check_modules(MPV REQUIRED IMPORTED_TARGET mpv)
+target_link_libraries(${BINARY_NAME} PRIVATE PkgConfig::MPV)
+
 target_include_directories(${BINARY_NAME} PRIVATE "${CMAKE_SOURCE_DIR}")

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -101,10 +101,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -404,18 +404,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
@@ -825,10 +825,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.10"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.1.2+5
+version: 1.2.0+6
 
 environment:
   sdk: ^3.9.0


### PR DESCRIPTION
## Summary

- **Feature:** synced lyrics view (tap album cover in the player)
- **Feature:** Linux window resize handles for the custom title bar
- **Refactor:** link libmpv at build time via pkg-config; drop runtime dlopen
- **Fix:** play/pause button state desync after a track loads
- **Fix:** lazy mpv init / lazy load when state was restored before player was ready
- **Fix:** wait for fileLoaded before issuing post-load seeks
- **Fix:** progress slider falls back to song metadata duration before mpv loads
- **Fix:** state restore no longer blocked by network-offline false positives
- **Fix:** library scan no longer reports phantom new albums
- **Chore:** bump pipewire 1.6.2 → 1.6.3
- **Chore:** big log cleanup

## Test plan

- [ ] Linux Flatpak: install the CI-built artifact, confirm playback works on a fresh start
- [ ] Linux Flatpak: tap album cover → lyrics view opens; tap a synced line → seeks + plays
- [ ] Linux Flatpak: drag window edges → window resizes
- [ ] Android: regressions in playback / queue navigation
- [ ] macOS: nothing visibly broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)